### PR TITLE
feat: add Bluetooth connectivity binary sensor per lock

### DIFF
--- a/custom_components/ttlock_ble/__init__.py
+++ b/custom_components/ttlock_ble/__init__.py
@@ -33,7 +33,12 @@ if TYPE_CHECKING:
         TtlockBleStoredKey,
     )
 
-PLATFORMS: list[Platform] = [Platform.EVENT, Platform.LOCK, Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.EVENT,
+    Platform.LOCK,
+    Platform.SENSOR,
+]
 
 
 async def async_setup_entry(

--- a/custom_components/ttlock_ble/binary_sensor.py
+++ b/custom_components/ttlock_ble/binary_sensor.py
@@ -60,6 +60,11 @@ class TtlockBleConnectionBinarySensor(TtlockBleEntity, BinarySensorEntity):
         """True iff the persistent BLE session to this lock is currently up."""
         return self._connection.is_connected
 
+    @property
+    def icon(self) -> str:
+        """Bluetooth icon that mirrors the live link state."""
+        return "mdi:bluetooth-connect" if self.is_on else "mdi:bluetooth-off"
+
     async def async_added_to_hass(self) -> None:
         """Subscribe to live BLE connect/disconnect transitions."""
         await super().async_added_to_hass()

--- a/custom_components/ttlock_ble/binary_sensor.py
+++ b/custom_components/ttlock_ble/binary_sensor.py
@@ -1,0 +1,82 @@
+"""Binary sensor platform for ttlock_ble — live BLE connection state."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .connection import connection_signal
+from .entity import TtlockBleEntity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from ttlock_ble import VirtualKey
+
+    from .connection import TtlockBleConnection
+    from .coordinator import TtlockBleDataUpdateCoordinator
+    from .data import TtlockBleConfigEntry
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: TtlockBleConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Create one connection binary sensor per `VirtualKey`."""
+    data = entry.runtime_data
+    async_add_entities(
+        TtlockBleConnectionBinarySensor(data.coordinator, key)
+        for key in data.virtual_keys
+    )
+
+
+class TtlockBleConnectionBinarySensor(TtlockBleEntity, BinarySensorEntity):
+    """Reports the live BLE link state for one lock."""
+
+    _attr_translation_key = "connection"
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: TtlockBleDataUpdateCoordinator,
+        key: VirtualKey,
+    ) -> None:
+        """Bind the binary sensor to its key + coordinator."""
+        super().__init__(coordinator, key)
+        self._attr_unique_id = f"{key.lockMac}_connection"
+
+    @property
+    def is_on(self) -> bool:
+        """True iff the persistent BLE session to this lock is currently up."""
+        return self._connection.is_connected
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to live BLE connect/disconnect transitions."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                connection_signal(self._key.lockMac),
+                self._on_connection_state,
+            ),
+        )
+
+    @callback
+    def _on_connection_state(self, _connected: bool) -> None:  # noqa: FBT001
+        """Push the freshest BLE link state into HA's state machine."""
+        self.async_write_ha_state()
+
+    @property
+    def _connection(self) -> TtlockBleConnection:
+        """Return the persistent BLE connection wrapper for this lock."""
+        return self.coordinator.connections[self._key.lockMac]

--- a/custom_components/ttlock_ble/connection.py
+++ b/custom_components/ttlock_ble/connection.py
@@ -45,6 +45,11 @@ def event_signal(mac: str) -> str:
     return f"{DOMAIN}_event_{mac.lower()}"
 
 
+def connection_signal(mac: str) -> str:
+    """Dispatcher signal that carries BLE up/down transitions for `mac`."""
+    return f"{DOMAIN}_connection_{mac.lower()}"
+
+
 class TtlockBleConnection:
     """Maintain a long-lived BLE session with one TTLock lock."""
 
@@ -192,6 +197,7 @@ class TtlockBleConnection:
         client.add_event_listener(self._on_event)
         self._client = client
         self._disconnected.clear()
+        self._broadcast_connection_state(connected=True)
         return client
 
     async def _async_disconnect_locked(self) -> None:
@@ -200,9 +206,18 @@ class TtlockBleConnection:
             return
         client = self._client
         self._client = None
+        self._broadcast_connection_state(connected=False)
         client.remove_event_listener(self._on_event)
         with contextlib.suppress(Exception):
             await client.disconnect()
+
+    def _broadcast_connection_state(self, *, connected: bool) -> None:
+        """Notify subscribers that the BLE link to this lock just changed."""
+        async_dispatcher_send(
+            self._hass,
+            connection_signal(self._key.lockMac),
+            connected,
+        )
 
     def _on_event(self, event: LockEvent) -> None:
         """Forward a push event onto HA's dispatcher (called by the BLE layer)."""

--- a/custom_components/ttlock_ble/translations/en.json
+++ b/custom_components/ttlock_ble/translations/en.json
@@ -58,6 +58,11 @@
         }
     },
     "entity": {
+        "binary_sensor": {
+            "connection": {
+                "name": "Bluetooth connection"
+            }
+        },
         "lock": {
             "lock": {
                 "name": "Lock"

--- a/custom_components/ttlock_ble/translations/pt-BR.json
+++ b/custom_components/ttlock_ble/translations/pt-BR.json
@@ -58,6 +58,11 @@
         }
     },
     "entity": {
+        "binary_sensor": {
+            "connection": {
+                "name": "Conexão Bluetooth"
+            }
+        },
         "lock": {
             "lock": {
                 "name": "Fechadura"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from custom_components.ttlock_ble.connection import connection_signal
+
+
+async def test_connection_binary_sensor_created_for_each_key(
+    hass,
+    setup_integration,
+) -> None:
+    assert len(hass.states.async_all("binary_sensor")) == 1
+
+
+async def test_connection_binary_sensor_reflects_initial_state(
+    hass,
+    setup_integration,
+) -> None:
+    state = hass.states.async_all("binary_sensor")[0]
+    assert state.state == "on"
+
+
+async def test_connection_binary_sensor_device_class(
+    hass,
+    setup_integration,
+) -> None:
+    state = hass.states.async_all("binary_sensor")[0]
+    assert state.attributes["device_class"] == "connectivity"
+
+
+async def test_connection_binary_sensor_has_unique_id(
+    hass,
+    setup_integration,
+    sample_virtual_key,
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    state = hass.states.async_all("binary_sensor")[0]
+    registry = er.async_get(hass)
+    entry = registry.async_get(state.entity_id)
+    assert entry is not None
+    assert entry.unique_id == f"{sample_virtual_key.lockMac}_connection"
+
+
+async def test_connection_binary_sensor_is_diagnostic(
+    hass,
+    setup_integration,
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    state = hass.states.async_all("binary_sensor")[0]
+    registry = er.async_get(hass)
+    entry = registry.async_get(state.entity_id)
+    assert entry is not None
+    assert entry.entity_category == er.EntityCategory.DIAGNOSTIC
+
+
+async def test_connection_binary_sensor_updates_on_signal(
+    hass,
+    setup_integration,
+    sample_virtual_key,
+    mock_ttlock_connection,
+) -> None:
+    """A dispatcher signal pushes the freshest connection state without polling."""
+    state = hass.states.async_all("binary_sensor")[0]
+    assert state.state == "on"
+    mock_ttlock_connection.is_connected = False
+    async_dispatcher_send(
+        hass,
+        connection_signal(sample_virtual_key.lockMac),
+        False,  # noqa: FBT003
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(state.entity_id).state == "off"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -55,6 +55,25 @@ async def test_connection_binary_sensor_is_diagnostic(
     assert entry.entity_category == er.EntityCategory.DIAGNOSTIC
 
 
+async def test_connection_binary_sensor_icon_reflects_state(
+    hass,
+    setup_integration,
+    sample_virtual_key,
+    mock_ttlock_connection,
+) -> None:
+    """Icon switches between bluetooth-connect and bluetooth-off."""
+    state = hass.states.async_all("binary_sensor")[0]
+    assert state.attributes["icon"] == "mdi:bluetooth-connect"
+    mock_ttlock_connection.is_connected = False
+    async_dispatcher_send(
+        hass,
+        connection_signal(sample_virtual_key.lockMac),
+        False,  # noqa: FBT003
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(state.entity_id).attributes["icon"] == "mdi:bluetooth-off"
+
+
 async def test_connection_binary_sensor_updates_on_signal(
     hass,
     setup_integration,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,12 +9,20 @@ from ttlock_ble import LockEvent, TTLockError
 
 from custom_components.ttlock_ble.connection import (
     TtlockBleConnection,
+    connection_signal,
     event_signal,
 )
 
 
 def test_event_signal_lowercases_mac() -> None:
     assert event_signal("AA:BB:CC:DD:EE:FF") == "ttlock_ble_event_aa:bb:cc:dd:ee:ff"
+
+
+def test_connection_signal_lowercases_mac() -> None:
+    assert (
+        connection_signal("AA:BB:CC:DD:EE:FF")
+        == "ttlock_ble_connection_aa:bb:cc:dd:ee:ff"
+    )
 
 
 async def test_is_connected_false_before_start(hass, sample_virtual_key) -> None:
@@ -308,3 +316,45 @@ async def test_on_disconnected_wakes_maintain_loop(
     assert not conn._disconnected.is_set()
     conn._on_disconnected(mock_ttlock_client)
     assert conn._disconnected.is_set()
+
+
+async def test_connection_signal_fires_on_connect_and_disconnect(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    """Successful connect emits True; tearing the session down emits False."""
+    received: list[bool] = []
+    async_dispatcher_connect(
+        hass,
+        connection_signal(sample_virtual_key.lockMac),
+        received.append,
+    )
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    await conn.async_query_state()
+    await hass.async_block_till_done()
+    assert received == [True]
+    await conn.async_stop()
+    await hass.async_block_till_done()
+    assert received == [True, False]
+
+
+async def test_connection_signal_not_emitted_when_connect_fails(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    """If BLE connect raises, nothing is broadcast — state stayed `down`."""
+    received: list[bool] = []
+    async_dispatcher_connect(
+        hass,
+        connection_signal(sample_virtual_key.lockMac),
+        received.append,
+    )
+    mock_ttlock_client.connect = AsyncMock(side_effect=TTLockError("ble fail"))
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    await conn.async_query_state()
+    await hass.async_block_till_done()
+    assert received == []


### PR DESCRIPTION
## Summary
- New diagnostic `binary_sensor.<lock>_bluetooth_connection` per `VirtualKey` with `device_class=connectivity`. Reports whether the persistent BLE session to that lock is currently up.
- `connection.py` now emits a `ttlock_ble_connection_<mac>` dispatcher signal whenever the session goes up or down — the sensor adopts the change instantly, without waiting for the next `scan_interval` poll.
- Added `Platform.BINARY_SENSOR` to the integration setup.
- Translations: `Bluetooth connection` (en) / `Conexão Bluetooth` (pt-BR).

## Why
The existing battery sensor and lock entity reflect the *last successful poll*. With a 5-min default `scan_interval`, the UI can't tell whether the BLE link is currently up, only whether it was 5 minutes ago. A diagnostic connectivity sensor surfaces that information cheaply.

## Test plan
- [x] `scripts/lint` clean (ruff + mypy)
- [x] `pytest tests/` — 154 passed, 97.45% coverage (gate 95%)
- [x] New tests cover: per-key creation, initial state, `device_class=connectivity`, diagnostic entity_category, unique_id, dispatcher-driven update, signal emission on connect/disconnect, no signal when connect fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)