### PR TITLE
ci: use PAT for release-please authoring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,9 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     steps:
-      - name: Generate App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.RELEASE_PLEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - name: Run release-please
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
Switches `release.yml` to use a Personal Access Token (`RELEASE_PLEASE_PAT`) so that releases, tags and release PRs are attributed to the user account instead of the `github-actions[bot]` / GitHub App bot identity.

## Notes
- The PAT was created as a fine-grained token with `Contents: write`, `Pull requests: write`, `Workflows: write`, `Metadata: read`, scoped to this repo.
- For HA repos: the previous `Generate App token` step is removed, along with the `RELEASE_PLEASE_APP_*` secret references. The App-token secrets themselves remain in the repo settings for now in case a quick rollback is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)