### PR TITLE
ci: add CODEOWNERS to auto-request reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @roquerodrigo


### PR DESCRIPTION
## Summary
Adds `.github/CODEOWNERS` with `* @roquerodrigo` so that every PR opened by someone other than the owner (Dependabot, future contributors) automatically requests `@roquerodrigo` as reviewer.

## Note
GitHub does **not** allow self-review requests, so PRs you author yourself will not be auto-assigned to you. CODEOWNERS triggers only when the PR author differs from the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)