### PR TITLE
ci: auto-assign @roquerodrigo to every new PR

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,20 @@
+name: Auto-assign owner
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    name: Assign @roquerodrigo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add assignee
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
+        run: gh pr edit "$NUMBER" --add-assignee roquerodrigo


### PR DESCRIPTION
## Summary
Adds `.github/workflows/auto-assign.yml`. On every `pull_request_target: opened` and `reopened`, the workflow adds `@roquerodrigo` as the PR assignee via `gh pr edit`.

Pairs with the recently added `CODEOWNERS` (which handles review requests). Together they ensure every new PR — even those opened by Dependabot — surfaces in your assigned/review queues.

GitHub allows self-assignment, so this also fires on PRs you author yourself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)