### PR TITLE
ci: sync pyproject.toml version + add to release-please

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-ttlock-ble"
-version = "0.0.0"
+version = "3.2.0"
 description = "Home Assistant integration for DLock-XP / TTLock smart locks (BLE)"
 requires-python = ">=3.14.2"
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,21 +13,68 @@
           "type": "json",
           "path": "custom_components/ttlock_ble/manifest.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.project.version"
         }
       ],
       "changelog-sections": [
-        { "type": "feat", "section": "Features" },
-        { "type": "fix", "section": "Bug Fixes" },
-        { "type": "perf", "section": "Performance Improvements" },
-        { "type": "deps", "section": "Dependencies" },
-        { "type": "revert", "section": "Reverts" },
-        { "type": "docs", "section": "Documentation" },
-        { "type": "build", "section": "Build System", "hidden": true },
-        { "type": "ci", "section": "Continuous Integration", "hidden": true },
-        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
-        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
-        { "type": "style", "section": "Styles", "hidden": true },
-        { "type": "test", "section": "Tests", "hidden": true }
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "deps",
+          "section": "Dependencies"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "build",
+          "section": "Build System",
+          "hidden": true
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration",
+          "hidden": true
+        },
+        {
+          "type": "chore",
+          "section": "Miscellaneous Chores",
+          "hidden": true
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring",
+          "hidden": true
+        },
+        {
+          "type": "style",
+          "section": "Styles",
+          "hidden": true
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": true
+        }
       ]
     }
   }

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,7 @@ wheels = [
 
 [[package]]
 name = "ha-ttlock-ble"
-version = "0.0.0"
+version = "3.2.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Bumps ``pyproject.toml`` ``[project]`` version from the ``0.0.0`` placeholder to the current ``manifest.json`` version.
- Adds ``pyproject.toml`` to ``release-please-config.json`` ``extra-files`` so future releases bump both files together.

The pyproject ``[project]`` block exists only so uv recognises the directory as a managed project (``[tool.uv] package = false``). Keeping the version in sync removes a small but real source of confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)