### PR TITLE
refactor: expose unique_id as a property on all entities

### DIFF
--- a/custom_components/ttlock_ble/binary_sensor.py
+++ b/custom_components/ttlock_ble/binary_sensor.py
@@ -19,10 +19,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from ttlock_ble import VirtualKey
-
     from .connection import TtlockBleConnection
-    from .coordinator import TtlockBleDataUpdateCoordinator
     from .data import TtlockBleConfigEntry
 
 
@@ -46,14 +43,10 @@ class TtlockBleConnectionBinarySensor(TtlockBleEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(
-        self,
-        coordinator: TtlockBleDataUpdateCoordinator,
-        key: VirtualKey,
-    ) -> None:
-        """Bind the binary sensor to its key + coordinator."""
-        super().__init__(coordinator, key)
-        self._attr_unique_id = f"{key.lockMac}_connection"
+    @property
+    def unique_id(self) -> str:
+        """Return a stable unique id for this entity."""
+        return f"{self._key.lockMac}_connection"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/ttlock_ble/event.py
+++ b/custom_components/ttlock_ble/event.py
@@ -122,8 +122,12 @@ class TtlockBleLogEvent(TtlockBleEntity, EventEntity):
     ) -> None:
         """Bind the entity to its key + coordinator."""
         super().__init__(coordinator, key)
-        self._attr_unique_id = f"{key.lockMac}_log"
         self._attr_event_types = LOG_EVENT_TYPES
+
+    @property
+    def unique_id(self) -> str:
+        """Return a stable unique id for this entity."""
+        return f"{self._key.lockMac}_log"
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to the log dispatcher signal."""

--- a/custom_components/ttlock_ble/lock.py
+++ b/custom_components/ttlock_ble/lock.py
@@ -76,10 +76,14 @@ class TtlockBleLock(TtlockBleEntity, LockEntity):
         """Bind the entity to its connection + coordinator + key."""
         super().__init__(coordinator, key)
         self._connection = connection
-        self._attr_unique_id = f"{key.lockMac}_lock"
         self._attr_is_locked = None
         self._settle_until: float = 0.0
         self._sync_from_coordinator()
+
+    @property
+    def unique_id(self) -> str:
+        """Return a stable unique id for this entity."""
+        return f"{self._key.lockMac}_lock"
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to push-event notifications for the lock's MAC."""

--- a/custom_components/ttlock_ble/sensor.py
+++ b/custom_components/ttlock_ble/sensor.py
@@ -54,9 +54,13 @@ class TtlockBleBatterySensor(TtlockBleEntity, SensorEntity):
     ) -> None:
         """Bind the sensor to its key + coordinator."""
         super().__init__(coordinator, key)
-        self._attr_unique_id = f"{key.lockMac}_battery"
         self._attr_native_value: int | None = None
         self._sync_from_coordinator()
+
+    @property
+    def unique_id(self) -> str:
+        """Return a stable unique id for this entity."""
+        return f"{self._key.lockMac}_battery"
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to push-event notifications for the lock's MAC."""


### PR DESCRIPTION
## Summary

Migrate every entity's `unique_id` from an `_attr_unique_id` assignment in `__init__` to a computed `@property`, per the updated ha-integration-dev blueprint invariant (`_attr_unique_id` in `__init__` is no longer permitted).

The produced `unique_id` strings are **byte-identical** — this is a pure structural refactor with no behaviour change. Each property derives the MAC from the already-stored `self._key.lockMac` (set by the base `TtlockBleEntity.__init__`), so no redundant instance attributes were added.

## Files converted

- `custom_components/ttlock_ble/lock.py` — `f"{...}_lock"` (kept `__init__`)
- `custom_components/ttlock_ble/sensor.py` — `f"{...}_battery"` (kept `__init__`)
- `custom_components/ttlock_ble/event.py` — `f"{...}_log"` (kept `__init__`)
- `custom_components/ttlock_ble/binary_sensor.py` — `f"{...}_connection"` (`__init__` dropped entirely; it only set `_attr_unique_id`, so its now-unused `VirtualKey` / coordinator type imports were removed)

## Verification

- `uv run ruff format --check .` — 45 files already formatted
- `uv run ruff check .` — All checks passed
- `uv run mypy custom_components/ttlock_ble` — no issues (30 source files)
- `uv run pytest` — 153 passed, 95.08% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)