### PR TITLE
chore: Dependabot weekly Mondays 09:00 BRT

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
     groups:
       github-actions:
         patterns:
@@ -19,6 +25,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
     groups:
       python-deps:
         patterns:


### PR DESCRIPTION
Padroniza o agendamento do Dependabot para **semanal, segunda-feira às 09:00 (America/Sao_Paulo)**.

Altera apenas os blocos `schedule:` de cada `updates[]` (todos os ecossistemas). Groups, `ignore`, `update-types` e `commit-message` ficam intactos. Repositórios que estavam em `daily` passam a `weekly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rd5TvxTLK2VVaVMhg3nVXH
