### PR TITLE
ci: assign open issues and pull requests to the repository owner

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -9,27 +9,13 @@ on:
     - cron: "17 6 * * *"
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
-
 concurrency:
   group: auto-assign
   cancel-in-progress: false
 
 jobs:
-  assign:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Assign unassigned open issues and pull requests to the repository owner
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ASSIGNEE: ${{ github.repository_owner }}
-        run: |
-          gh api "repos/${GITHUB_REPOSITORY}/issues?state=open&per_page=100" --paginate \
-            --jq '.[] | select(.assignees | length == 0) | .number' |
-            while read -r number; do
-              gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${number}/assignees" \
-                -f "assignees[]=${ASSIGNEE}" --silent
-              echo "Assigned #${number} to ${ASSIGNEE}"
-            done
+  auto-assign:
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: roquerodrigo/.github/.github/workflows/auto-assign.yml@main

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,35 @@
+name: Auto-assign
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened]
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: auto-assign
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign unassigned open issues and pull requests to the repository owner
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASSIGNEE: ${{ github.repository_owner }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/issues?state=open&per_page=100" --paginate \
+            --jq '.[] | select(.assignees | length == 0) | .number' |
+            while read -r number; do
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${number}/assignees" \
+                -f "assignees[]=${ASSIGNEE}" --silent
+              echo "Assigned #${number} to ${ASSIGNEE}"
+            done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,6 @@ jobs:
       security-events: write
     uses: roquerodrigo/.github/.github/workflows/ha-codeql.yml@v2
 
-  auto-assign:
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
-    permissions:
-      pull-requests: write
-    uses: roquerodrigo/.github/.github/workflows/ha-auto-assign.yml@v2
-    secrets: inherit
 
   update-pr-branch:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       security-events: write
     uses: roquerodrigo/.github/.github/workflows/ha-codeql.yml@v2
 
-
   update-pr-branch:
     if: github.event_name == 'pull_request'
     needs: [lint, tests, validate]


### PR DESCRIPTION
Adds a dedicated Auto-assign workflow and removes the auto-assign job previously defined in the CI workflow, which only covered newly opened pull requests.

The workflow delegates to the shared reusable workflow and assigns the repository owner to any open issue or pull request left without an assignee. It runs on opened or reopened issues and pull requests, and once a day as a safety net for items no event covers - notably pull requests opened by Actions with the default token, whose runs would otherwise wait for approval.