### PR TITLE
ci: split the CI workflow into one file per concern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,33 +5,21 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    - cron: "0 0 * * 0"   # CodeQL weekly
 
 permissions:
   contents: read
 
 jobs:
   lint:
-    if: github.event_name != 'schedule'
     uses: roquerodrigo/.github/.github/workflows/ha-lint.yml@v2
 
   tests:
-    if: github.event_name != 'schedule'
     needs: lint
     uses: roquerodrigo/.github/.github/workflows/ha-tests.yml@v2
 
   validate:
-    if: github.event_name != 'schedule'
     needs: lint
     uses: roquerodrigo/.github/.github/workflows/ha-validate.yml@v2
-
-  codeql:
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    uses: roquerodrigo/.github/.github/workflows/ha-codeql.yml@v2
 
   update-pr-branch:
     if: github.event_name == 'pull_request'
@@ -40,12 +28,3 @@ jobs:
       contents: write
       pull-requests: write
     uses: roquerodrigo/.github/.github/workflows/ha-update-pr-branch.yml@v2
-
-  release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [lint, tests, validate]
-    permissions:
-      contents: write
-      pull-requests: write
-    uses: roquerodrigo/.github/.github/workflows/ha-release.yml@v2
-    secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,20 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: roquerodrigo/.github/.github/workflows/ha-codeql.yml@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: roquerodrigo/.github/.github/workflows/ha-release.yml@v2
+    secrets: inherit


### PR DESCRIPTION
Splits the CI workflow so each file covers a single concern.

CodeQL moves to its own workflow with the weekly schedule it already had, which removes the schedule trigger from CI and the guard every other job needed to opt out of it. Release moves to its own workflow triggered by a successful CI run on the default branch, so it stays gated on the same checks as before.

Job identifiers are unchanged, so the required status check names stay the same.