### PR TITLE
fix: track lock state from the lock's BLE advertisements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,10 @@ __init__.py      → instantiates one TtlockBleConnection per lock and a
                     DataUpdateCoordinator, performs the first refresh
 connection.py    → owns the long-lived BLE session, reconnect loop,
                     cooldown, and push-event dispatch
-coordinator.py   → polls every scan_interval seconds via each connection
+advertisement.py → decodes lock state + battery from the advertisements
+                    HA's bluetooth manager already receives, no connection
+coordinator.py   → polls every scan_interval seconds via each connection,
+                    and publishes the advertised state as it arrives
 lock.py          → LockEntity backed by the BLE connection
 sensor.py        → BatterySensor backed by the same poll + push events
 binary_sensor.py → connectivity BinarySensorEntity reflecting live BLE link state
@@ -99,8 +102,23 @@ event.py         → EventEntity that surfaces decoded LockEvent pushes
 - A long-lived `TTLockClient` (the SDK).
 - An `asyncio.Lock` serializing query/lock/unlock commands.
 - A reconnect maintain loop driven by an `asyncio.Event` the SDK's `disconnected_callback` toggles.
-- A post-drop cooldown: after any disconnect, sleeps `RECONNECT_COOLDOWN_SECONDS` (5 min) before reconnecting — no immediate retry. `async_query_state` honours `_cooldown_until`; user-driven `async_lock`/`async_unlock` bypass it.
+- A post-drop cooldown: after any disconnect, sleeps `RECONNECT_COOLDOWN_SECONDS` before reconnecting — no immediate retry. **The cooldown paces that loop only.** It used to also veto `async_query_state`, and since the lock drops every idle session within seconds the loop re-armed it constantly, so the configured `scan_interval` never actually ran a poll (issue #42). Reads are rate-limited by their own callers instead.
 - A dispatcher forwarder: any push event the SDK emits is fanned out on `ttlock_ble_event_<mac>` so the lock, sensor, and event entities can subscribe.
+
+### Passive advertisement tracking
+
+`advertisement.py` defines `TtlockBleAdvertisementTracker`, subscribed per MAC through HA's `async_register_callback`. The firmware folds the bolt position, a "new records pending" flag and the battery percentage into the manufacturer data of every advertisement, so `LockAdvertisement.from_manufacturer_data` (SDK) turns them into state for free.
+
+This is the **only** channel that reports an auto-lock: the firmware writes no operation-log record for it, and the lock drops the BLE session it pushes events on within seconds of going idle. The same applies to anything done from the official app or the keypad while we are not connected.
+
+Two details are load-bearing:
+
+- The decoded trailing address must equal the lock's MAC. A payload long enough to decode is not proof it is a TTLock payload, and that address is the only field whose value can be checked independently.
+- An advertisement that decodes reaches the entities via `async_set_updated_data`, which also **reschedules** the next poll — a lock that keeps advertising is never connected to just to be read.
+
+An advertisement we cannot decode falls back to a coordinator refresh, but only while no state is known yet: that bootstrap is what makes the entity available seconds after HA boots instead of after a full `scan_interval`. Refreshing on *every* advertisement (the old behaviour) is what made the cooldown look necessary in the first place.
+
+The diagnostics dump carries the last advertisement per lock, raw bytes included, with `decoded: null` when the payload does not match the layout we know — that is what makes a "state never updates" report answerable without a round trip.
 
 ### Diagnostics
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Local control of TTLock smart locks over Bluetooth, for [Home Assistant](https:/
 - **Real-time push events** — keypad presses, fingerprint reads, IC-card swipes, mechanical key turns, and auto-lock fires arrive as Home Assistant events the moment the lock emits them.
 - **Battery sensor** — diagnostic entity refreshed by every poll *and* every push, no extra BLE traffic.
 - **2FA-aware config flow** — handles TTLock's "new device" verification by emailing a one-time code and prompting for it.
-- **Persistent BLE session with drop-storm cooldown** — keeps the link warm to receive push events, but backs off for 5 minutes after three short drops to protect the lock's battery.
+- **Passive state tracking** — the bolt position and battery level are read from the lock's own BLE advertisements, with no connection and no battery cost. This is what catches an auto-lock or an operation done from the official app.
+- **Persistent BLE session with a post-drop cooldown** — keeps the link warm to receive push events, and waits before reconnecting so a lock in idle-sleep isn't thrashed.
 - **Reauth + reconfigure** — re-prompt for credentials in place when the cloud rejects the cached login, or edit them via the integration's three-dot menu.
 - **Diagnostics** — downloadable dump with credentials/keys redacted.
 - **Translations** — English and Brazilian Portuguese (parity enforced by tests).
@@ -45,7 +46,7 @@ The Bluetooth radio HA already manages (USB dongle, built-in adapter, or proxy) 
 
 Settings → Devices & Services → TTLock BLE → **Configure** lets you tune:
 
-- `scan_interval` (default 3600 s, minimum 60 s) — how often the coordinator polls the lock for state when no push events are arriving.
+- `scan_interval` (default 3600 s, minimum 60 s) — how often the coordinator opens a BLE session to read state. Every advertisement received postpones the next poll, so a lock in range is rarely polled at all; lowering this only adds connections (and battery drain) for a lock that has gone quiet.
 
 To edit credentials without removing and re-adding, use the integration's three-dot menu → **Reconfigure**.
 
@@ -53,8 +54,8 @@ To edit credentials without removing and re-adding, use the integration's three-
 
 The lock's TTLock firmware aggressively closes idle BLE sessions (~5 s of silence and it drops). The integration:
 
-1. Keeps a persistent BLE session via `connection.py`, reconnecting on every drop signalled by bleak.
-2. Detects when the lock is in idle-sleep mode (≥ 3 sub-30 s sessions) and enters a 5-minute cooldown so we don't drain its battery thrashing.
+1. Reads the bolt position and battery level straight out of the lock's BLE advertisements. This costs no connection at all and is the only channel that reports an operation performed while Home Assistant is not connected — an auto-lock, the official app, a keypad code.
+2. Keeps a persistent BLE session via `connection.py`, reconnecting on every drop signalled by bleak, and waiting out a cooldown before doing so.
 3. After a user-initiated `lock`/`unlock`, the SDK keeps the link alive for 25 s so push events (the lock's reports of keypad operations, auto-locks, etc.) reach Home Assistant in real time.
 4. Each push event carries the decoded `lock_state` and `battery` when the firmware emits a heartbeat-style payload, letting the entities update without a follow-up query.
 
@@ -84,6 +85,7 @@ rm config/.storage/core.entity_registry config/.storage/core.device_registry
 ```
 custom_components/ttlock_ble/
 ├── __init__.py        # async_setup_entry / unload / reload + bluetooth callbacks
+├── advertisement.py   # TtlockBleAdvertisementTracker: state from advertisements
 ├── api.py             # TtlockBleApiClient: TTLockCloud wrapper (cloud bootstrap only)
 ├── brand/             # icon / logo PNGs (local placeholder for HA brand registry)
 ├── config_flow.py     # user / verify_code / reauth_confirm / reconfigure steps

--- a/custom_components/ttlock_ble/__init__.py
+++ b/custom_components/ttlock_ble/__init__.py
@@ -5,27 +5,18 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING, cast
 
-from homeassistant.components.bluetooth import (
-    BluetoothCallbackMatcher,
-    BluetoothScanningMode,
-    async_register_callback,
-)
 from homeassistant.const import CONF_SCAN_INTERVAL, Platform
-from homeassistant.core import callback
 
 from ttlock_ble import VirtualKey
 
+from .advertisement import TtlockBleAdvertisementTracker
 from .connection import TtlockBleConnection
 from .const import DEFAULT_SCAN_INTERVAL_SECONDS, DOMAIN
 from .coordinator import TtlockBleDataUpdateCoordinator
 from .data import TtlockBleData
 
 if TYPE_CHECKING:
-    from homeassistant.components.bluetooth import (
-        BluetoothChange,
-        BluetoothServiceInfoBleak,
-    )
-    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+    from homeassistant.core import HomeAssistant
 
     from .data import (
         TtlockBleConfigData,
@@ -65,10 +56,8 @@ async def async_setup_entry(
         connections=connections,
     )
 
-    bluetooth_unsubs = _async_register_bluetooth_callbacks(
-        hass,
+    bluetooth_unsubs = TtlockBleAdvertisementTracker(hass, coordinator).async_register(
         virtual_keys,
-        coordinator,
     )
 
     # Trigger the first state refresh without awaiting it, so the config entry
@@ -93,40 +82,6 @@ async def async_setup_entry(
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
-
-
-@callback
-def _async_register_bluetooth_callbacks(
-    hass: HomeAssistant,
-    virtual_keys: list[VirtualKey],
-    coordinator: TtlockBleDataUpdateCoordinator,
-) -> list[CALLBACK_TYPE]:
-    """
-    Refresh the coordinator the moment HA's bluetooth manager sees a lock.
-
-    Without this the coordinator only re-polls every `scan_interval`, so the
-    entity can spend many minutes `unavailable` after HA boots — HA's bluetooth
-    discovery typically lags integration setup by 30-120 seconds. Subscribing
-    per-MAC lets the UI become available within seconds of the first
-    advertisement.
-    """
-
-    @callback
-    def _on_advertisement(
-        _service_info: BluetoothServiceInfoBleak,
-        _change: BluetoothChange,
-    ) -> None:
-        hass.async_create_task(coordinator.async_request_refresh())
-
-    return [
-        async_register_callback(
-            hass,
-            _on_advertisement,
-            BluetoothCallbackMatcher(address=key.lockMac, connectable=True),
-            BluetoothScanningMode.ACTIVE,
-        )
-        for key in virtual_keys
-    ]
 
 
 async def async_unload_entry(

--- a/custom_components/ttlock_ble/advertisement.py
+++ b/custom_components/ttlock_ble/advertisement.py
@@ -1,0 +1,123 @@
+"""Passive advertisement tracking for ttlock_ble."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING
+
+from homeassistant.components.bluetooth import (
+    BluetoothCallbackMatcher,
+    BluetoothScanningMode,
+    async_register_callback,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import format_mac
+
+from ttlock_ble import LockAdvertisement
+
+from .const import LOGGER
+
+if TYPE_CHECKING:
+    from homeassistant.components.bluetooth import (
+        BluetoothChange,
+        BluetoothServiceInfoBleak,
+    )
+    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+
+    from ttlock_ble import VirtualKey
+
+    from .coordinator import TtlockBleDataUpdateCoordinator
+
+
+class TtlockBleAdvertisementTracker:
+    """
+    Keep lock state fresh from the advertisements HA's bluetooth manager sees.
+
+    The firmware publishes the bolt position and the battery level in the
+    manufacturer data of every advertisement, so tracking them costs no
+    BLE session at all. This is the only channel that reports an
+    out-of-band change — auto-lock, the official app, a keypad code —
+    once the lock has dropped the connection it pushes events on, which
+    it does within seconds of going idle.
+
+    An advertisement that decodes into a state also postpones the next
+    poll: `async_set_updated_data` reschedules the coordinator, so a lock
+    that keeps advertising is never connected to just to be read.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: TtlockBleDataUpdateCoordinator,
+    ) -> None:
+        """Bind the tracker to the coordinator it feeds."""
+        self._hass = hass
+        self._coordinator = coordinator
+
+    @callback
+    def async_register(self, virtual_keys: list[VirtualKey]) -> list[CALLBACK_TYPE]:
+        """Subscribe to each lock's advertisements; return the unsubscribe callables."""
+        return [
+            async_register_callback(
+                self._hass,
+                partial(self._async_on_advertisement, key.lockMac),
+                BluetoothCallbackMatcher(address=key.lockMac, connectable=False),
+                BluetoothScanningMode.ACTIVE,
+            )
+            for key in virtual_keys
+        ]
+
+    @callback
+    def _async_on_advertisement(
+        self,
+        mac: str,
+        service_info: BluetoothServiceInfoBleak,
+        _change: BluetoothChange,
+    ) -> None:
+        """Adopt the advertised state, or fall back to a poll when it can't be read."""
+        advertisement = self._decode(mac, service_info)
+        if advertisement is not None:
+            self._coordinator.async_apply_advertisement(mac, advertisement)
+            return
+        if self._coordinator.async_has_state(mac):
+            return
+        LOGGER.debug(
+            "No state in the advertisement for %s, polling instead (%s)",
+            mac,
+            {
+                company_id: payload.hex()
+                for company_id, payload in service_info.manufacturer_data.items()
+            },
+        )
+        self._hass.async_create_task(self._coordinator.async_request_refresh())
+
+    def _decode(
+        self,
+        mac: str,
+        service_info: BluetoothServiceInfoBleak,
+    ) -> LockAdvertisement | None:
+        """
+        Return the entry of `manufacturer_data` that decodes as this lock's state.
+
+        The address the advertisement carries has to match the lock we
+        expect: a payload long enough to decode is not proof that it is a
+        TTLock payload, and the trailing address is the only field with a
+        value we can check independently.
+        """
+        expected = format_mac(mac)
+        for company_id, payload in service_info.manufacturer_data.items():
+            advertisement = LockAdvertisement.from_manufacturer_data(
+                company_id,
+                payload,
+            )
+            if advertisement is None:
+                continue
+            if format_mac(advertisement.lock_mac) == expected:
+                return advertisement
+            LOGGER.debug(
+                "Ignoring advertisement for %s: decoded address %s does not match (%s)",
+                mac,
+                advertisement.lock_mac,
+                payload.hex(),
+            )
+        return None

--- a/custom_components/ttlock_ble/connection.py
+++ b/custom_components/ttlock_ble/connection.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import time
 from typing import TYPE_CHECKING
 
 from homeassistant.components.bluetooth import async_ble_device_from_address
@@ -65,7 +64,6 @@ class TtlockBleConnection:
         self._task: asyncio.Task[None] | None = None
         self._closing = False
         self._disconnected = asyncio.Event()
-        self._cooldown_until: float = 0.0
         self._seen_records: set[int] = set()
 
     @property
@@ -100,26 +98,16 @@ class TtlockBleConnection:
         async with self._lock:
             await self._async_disconnect_locked()
 
-    async def async_query_state(
-        self,
-        *,
-        force_cooldown_bypass: bool = False,
-    ) -> tuple[LockState | None, int | None] | None:
+    async def async_query_state(self) -> tuple[LockState | None, int | None] | None:
         """
         Return `(lock_state, battery)` through the live connection.
 
-        Returns `None` immediately while a long-backoff cooldown is in
-        effect — letting periodic coordinator polls hammer the lock would
-        defeat the very cooldown the maintain loop entered. User-driven
-        callers (`async_lock`/`async_unlock`, or the lock entity's
-        post-command follow-up) opt out via `force_cooldown_bypass=True`.
+        Returns `None` when the lock is out of range or the query failed.
+        Every caller is already rate-limited — the coordinator by
+        `scan_interval`, the lock entity by the user pressing a button —
+        so the reconnect cooldown the maintain loop keeps is deliberately
+        not consulted here: it paces the background loop, not the reads.
         """
-        if not force_cooldown_bypass and time.monotonic() < self._cooldown_until:
-            LOGGER.debug(
-                "Skipping query for %s — connection cooldown active",
-                self._key.lockMac,
-            )
-            return None
         async with self._lock:
             client = await self._async_ensure_connected_locked()
             if client is None:
@@ -285,6 +273,9 @@ class TtlockBleConnection:
         that drains the lock's battery. Connect failures (device not yet
         advertising) use a separate exponential backoff so first-boot
         scans don't wait the full cooldown.
+
+        The cooldown paces this loop only. State stays fresh meanwhile
+        through the lock's advertisements, which cost no session at all.
         """
         backoff = RECONNECT_INITIAL_BACKOFF
         while not self._closing:
@@ -297,11 +288,7 @@ class TtlockBleConnection:
                     continue
                 backoff = RECONNECT_INITIAL_BACKOFF
                 await self._disconnected.wait()
-                self._cooldown_until = time.monotonic() + RECONNECT_COOLDOWN_SECONDS
-                try:
-                    await asyncio.sleep(RECONNECT_COOLDOWN_SECONDS)
-                finally:
-                    self._cooldown_until = 0.0
+                await asyncio.sleep(RECONNECT_COOLDOWN_SECONDS)
             except asyncio.CancelledError:
                 raise
             except Exception:  # noqa: BLE001

--- a/custom_components/ttlock_ble/coordinator.py
+++ b/custom_components/ttlock_ble/coordinator.py
@@ -5,6 +5,10 @@ Reads lock state through the per-lock `TtlockBleConnection` (which keeps
 a persistent BLE session and pushes events out-of-band). The
 coordinator only owns the periodic state refresh; it does not open BLE
 connections itself.
+
+State also arrives without any poll: `async_apply_advertisement`
+publishes what `TtlockBleAdvertisementTracker` decodes from the lock's
+advertisements, which is the only channel that reports an auto-lock.
 """
 
 from __future__ import annotations
@@ -12,7 +16,10 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from ttlock_ble import LockState
 
 from .const import DOMAIN, LOGGER
 
@@ -20,6 +27,8 @@ if TYPE_CHECKING:
     from datetime import timedelta
 
     from homeassistant.core import HomeAssistant
+
+    from ttlock_ble import LockAdvertisement
 
     from .connection import TtlockBleConnection
     from .data import (
@@ -58,6 +67,37 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
     def connections(self) -> dict[str, TtlockBleConnection]:
         """Return the per-MAC connection map this coordinator polls."""
         return self._connections
+
+    @callback
+    def async_has_state(self, mac: str) -> bool:
+        """Report whether a lock state has ever been read for `mac`, by any channel."""
+        snapshot = (self.data or {}).get(mac)
+        return snapshot is not None and snapshot.get("locked") is not None
+
+    @callback
+    def async_apply_advertisement(
+        self,
+        mac: str,
+        advertisement: LockAdvertisement,
+    ) -> None:
+        """
+        Publish state decoded from a BLE advertisement, without polling the lock.
+
+        Also reschedules the next poll: a lock that keeps advertising
+        reports itself for free, so there is nothing to connect for.
+        """
+        LOGGER.debug(
+            "Advertised state for %s (lock_state=%s battery=%d)",
+            mac,
+            advertisement.lock_state.name,
+            advertisement.battery,
+        )
+        snapshot: TtlockBleLockState = {
+            "locked": advertisement.lock_state is LockState.LOCKED,
+            "battery_level": advertisement.battery,
+            "available": True,
+        }
+        self.async_set_updated_data({**(self.data or {}), mac: snapshot})
 
     async def _async_update_data(self) -> TtlockBleCoordinatorData:
         """Poll every connection once and return the aggregated state map."""

--- a/custom_components/ttlock_ble/data/__init__.py
+++ b/custom_components/ttlock_ble/data/__init__.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from .config_data import TtlockBleConfigData
 from .credentials_input import TtlockBleCredentialsInput
+from .diagnostics_advertisement import TtlockBleDiagnosticsAdvertisement
 from .diagnostics_entry import TtlockBleDiagnosticsEntry
 from .diagnostics_lock_summary import TtlockBleDiagnosticsLockSummary
 from .diagnostics_payload import TtlockBleDiagnosticsPayload
@@ -36,6 +37,7 @@ __all__ = [
     "TtlockBleCoordinatorData",
     "TtlockBleCredentialsInput",
     "TtlockBleData",
+    "TtlockBleDiagnosticsAdvertisement",
     "TtlockBleDiagnosticsEntry",
     "TtlockBleDiagnosticsLockSummary",
     "TtlockBleDiagnosticsPayload",

--- a/custom_components/ttlock_ble/data/diagnostics_advertisement.py
+++ b/custom_components/ttlock_ble/data/diagnostics_advertisement.py
@@ -1,0 +1,22 @@
+"""Last advertisement seen for one lock, as captured in the diagnostics dump."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class TtlockBleDiagnosticsAdvertisement(TypedDict):
+    """
+    Last advertisement seen for one lock, as captured in the diagnostics dump.
+
+    `manufacturer_data` carries the raw bytes per company id, hex-encoded.
+    Keeping them in the dump is what makes a "state never updates" report
+    diagnosable: `decoded` is `None` whenever the payload does not match
+    the layout this integration knows, and the raw bytes are then the
+    only way to tell which layout the firmware actually uses.
+    """
+
+    source: str
+    rssi: int
+    manufacturer_data: dict[str, str]
+    decoded: dict[str, str | int | bool] | None

--- a/custom_components/ttlock_ble/data/diagnostics_payload.py
+++ b/custom_components/ttlock_ble/data/diagnostics_payload.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, TypedDict
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from .diagnostics_advertisement import TtlockBleDiagnosticsAdvertisement
     from .diagnostics_entry import TtlockBleDiagnosticsEntry
     from .diagnostics_lock_summary import TtlockBleDiagnosticsLockSummary
     from .lock_state import TtlockBleLockState
@@ -18,3 +19,4 @@ class TtlockBleDiagnosticsPayload(TypedDict):
     entry: TtlockBleDiagnosticsEntry
     locks: list[TtlockBleDiagnosticsLockSummary]
     coordinator_state: Mapping[str, TtlockBleLockState]
+    advertisements: Mapping[str, TtlockBleDiagnosticsAdvertisement | None]

--- a/custom_components/ttlock_ble/diagnostics.py
+++ b/custom_components/ttlock_ble/diagnostics.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+from homeassistant.components.bluetooth import async_last_service_info
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from ttlock_ble import LockAdvertisement
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -14,6 +17,7 @@ if TYPE_CHECKING:
 
     from .data import (
         TtlockBleConfigEntry,
+        TtlockBleDiagnosticsAdvertisement,
         TtlockBleDiagnosticsEntry,
         TtlockBleDiagnosticsLockSummary,
         TtlockBleDiagnosticsPayload,
@@ -33,7 +37,7 @@ TO_REDACT: frozenset[str] = frozenset(
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant,  # noqa: ARG001
+    hass: HomeAssistant,
     entry: TtlockBleConfigEntry,
 ) -> TtlockBleDiagnosticsPayload:
     """Return diagnostics for a config entry."""
@@ -60,6 +64,44 @@ async def async_get_config_entry_diagnostics(
         "entry": diag_entry,
         "locks": locks,
         "coordinator_state": dict(coordinator_state),
+        "advertisements": {
+            key["lockMac"]: _summarize_advertisement(hass, key["lockMac"])
+            for key in entry.runtime_data.keys
+        },
+    }
+
+
+def _summarize_advertisement(
+    hass: HomeAssistant,
+    mac: str,
+) -> TtlockBleDiagnosticsAdvertisement | None:
+    """Capture the last advertisement seen for `mac`, raw bytes included."""
+    service_info = async_last_service_info(hass, mac, connectable=False)
+    if service_info is None:
+        return None
+    decoded: dict[str, str | int | bool] | None = None
+    for company_id, payload in service_info.manufacturer_data.items():
+        advertisement = LockAdvertisement.from_manufacturer_data(company_id, payload)
+        if advertisement is not None:
+            decoded = {
+                "protocol_type": advertisement.protocol_type,
+                "protocol_version": advertisement.protocol_version,
+                "scene": advertisement.scene,
+                "lock_state": advertisement.lock_state.name,
+                "has_new_records": advertisement.has_new_records,
+                "is_setting_mode": advertisement.is_setting_mode,
+                "battery": advertisement.battery,
+                "lock_mac": advertisement.lock_mac,
+            }
+            break
+    return {
+        "source": service_info.source,
+        "rssi": service_info.rssi,
+        "manufacturer_data": {
+            str(company_id): payload.hex()
+            for company_id, payload in service_info.manufacturer_data.items()
+        },
+        "decoded": decoded,
     }
 
 

--- a/custom_components/ttlock_ble/lock.py
+++ b/custom_components/ttlock_ble/lock.py
@@ -50,7 +50,9 @@ class TtlockBleLock(TtlockBleEntity, LockEntity):
     Smart lock backed by a persistent `TtlockBleConnection`.
 
     State is reported via `_attr_is_locked`. It is updated:
-    - On every coordinator refresh that returned a known lock state.
+    - On every coordinator refresh that returned a known lock state —
+      which includes the state decoded from the lock's advertisements,
+      the only channel that reports an auto-lock.
     - Optimistically the moment `async_lock`/`async_unlock` succeed.
     - On every push event the SDK forwards (keypad, fingerprint,
       auto-lock): the SDK keeps the BLE link alive for a configurable
@@ -147,9 +149,9 @@ class TtlockBleLock(TtlockBleEntity, LockEntity):
         """
         Copy `locked` from the coordinator snapshot into `_attr_is_locked`.
 
-        A `None` value (cooldown suppressed the poll, or the lock is
-        out of range) leaves the cached state untouched — the entity
-        keeps showing whatever was last known. The post-command settle
+        A `None` value (the lock is out of range, or the poll failed)
+        leaves the cached state untouched — the entity keeps showing
+        whatever was last known. The post-command settle
         window also suppresses conflicting coordinator data: the lock's
         BLE state can briefly disagree with the just-commanded state
         and we don't want the UI to bounce.
@@ -200,7 +202,7 @@ class TtlockBleLock(TtlockBleEntity, LockEntity):
 
     async def _async_query_and_apply(self) -> None:
         """Force-query state and apply it to `_attr_is_locked` if known."""
-        result = await self._connection.async_query_state(force_cooldown_bypass=True)
+        result = await self._connection.async_query_state()
         if result is None:
             LOGGER.debug(
                 "Forced query for %s returned no state",

--- a/custom_components/ttlock_ble/manifest.json
+++ b/custom_components/ttlock_ble/manifest.json
@@ -9,7 +9,7 @@
     "bluetooth"
   ],
   "documentation": "https://github.com/roquerodrigo/ha-ttlock-ble",
-  "iot_class": "local_polling",
+  "iot_class": "local_push",
   "issue_tracker": "https://github.com/roquerodrigo/ha-ttlock-ble/issues",
   "requirements": [
     "ttlock-ble==0.1.7"

--- a/custom_components/ttlock_ble/manifest.json
+++ b/custom_components/ttlock_ble/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/roquerodrigo/ha-ttlock-ble/issues",
   "requirements": [
-    "ttlock-ble==0.1.7"
+    "ttlock-ble==0.1.8"
   ],
   "version": "3.2.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dev = [
     "pytest-cov==7.1.0",
     "pytest-homeassistant-custom-component==0.13.332",
     "serialx==1.8.2",
-    "ttlock-ble==0.1.7",
+    "ttlock-ble==0.1.8",
 ]
 lint = [
     "ruff==0.15.22",

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -1,0 +1,103 @@
+"""Coverage for the passive advertisement tracker."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+MAC = "AA:BB:CC:DD:EE:FF"
+MAC_TAIL = bytes.fromhex("ffeeddccbbaa")
+V3_COMPANY_ID = 0x0305
+
+
+def manufacturer_data(flags: int, battery: int = 77, tail: bytes = MAC_TAIL) -> dict:
+    """Build the `manufacturer_data` mapping of a protocol 5.3 advertisement."""
+    return {V3_COMPANY_ID: bytes([2, flags, battery, 0, 0, 0, 0]) + tail}
+
+
+def service_info(data: dict) -> MagicMock:
+    """Stand-in for the `BluetoothServiceInfoBleak` HA hands to the callback."""
+    info = MagicMock(name="BluetoothServiceInfoBleak")
+    info.address = MAC
+    info.manufacturer_data = data
+    return info
+
+
+@pytest.fixture
+def tracker(hass):
+    from custom_components.ttlock_ble.advertisement import (
+        TtlockBleAdvertisementTracker,
+    )
+
+    coordinator = MagicMock(name="Coordinator")
+    coordinator.async_request_refresh = AsyncMock(return_value=None)
+    coordinator.async_has_state = MagicMock(return_value=False)
+    return TtlockBleAdvertisementTracker(hass, coordinator), coordinator
+
+
+async def test_register_subscribes_once_per_lock(hass, sample_virtual_key) -> None:
+    from custom_components.ttlock_ble.advertisement import (
+        TtlockBleAdvertisementTracker,
+    )
+
+    with patch(
+        "custom_components.ttlock_ble.advertisement.async_register_callback",
+        return_value=MagicMock(),
+    ) as register:
+        unsubs = TtlockBleAdvertisementTracker(hass, MagicMock()).async_register(
+            [sample_virtual_key],
+        )
+    assert len(unsubs) == 1
+    matcher = register.call_args.args[2]
+    assert matcher["address"] == sample_virtual_key.lockMac
+
+
+async def test_unlocked_advertisement_updates_the_coordinator(tracker) -> None:
+    instance, coordinator = tracker
+    instance._async_on_advertisement(MAC, service_info(manufacturer_data(0x01)), None)
+    coordinator.async_apply_advertisement.assert_called_once()
+    mac, advertisement = coordinator.async_apply_advertisement.call_args.args
+    assert mac == MAC
+    assert advertisement.lock_state == 1
+    assert advertisement.battery == 77
+    coordinator.async_request_refresh.assert_not_called()
+
+
+async def test_locked_advertisement_updates_the_coordinator(tracker) -> None:
+    instance, coordinator = tracker
+    instance._async_on_advertisement(MAC, service_info(manufacturer_data(0x00)), None)
+    _mac, advertisement = coordinator.async_apply_advertisement.call_args.args
+    assert advertisement.lock_state == 0
+
+
+async def test_payload_for_another_address_is_ignored(tracker, hass) -> None:
+    instance, coordinator = tracker
+    other_tail = bytes.fromhex("112233445566")
+    instance._async_on_advertisement(
+        MAC,
+        service_info(manufacturer_data(0x01, tail=other_tail)),
+        None,
+    )
+    await hass.async_block_till_done()
+    coordinator.async_apply_advertisement.assert_not_called()
+
+
+async def test_undecodable_advertisement_falls_back_to_a_poll(tracker, hass) -> None:
+    instance, coordinator = tracker
+    instance._async_on_advertisement(MAC, service_info({0x004C: b"\x02\x15"}), None)
+    await hass.async_block_till_done()
+    coordinator.async_apply_advertisement.assert_not_called()
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_undecodable_advertisement_does_not_poll_once_state_is_known(
+    tracker,
+    hass,
+) -> None:
+    """The bootstrap poll is for the first reading only, never a per-advert refresh."""
+    instance, coordinator = tracker
+    coordinator.async_has_state = MagicMock(return_value=True)
+    instance._async_on_advertisement(MAC, service_info({0x004C: b"\x02\x15"}), None)
+    await hass.async_block_till_done()
+    coordinator.async_request_refresh.assert_not_awaited()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -265,50 +265,35 @@ async def test_maintain_loop_logs_unexpected_error(
     assert mock_ble_resolver.call_count >= 1
 
 
-async def test_query_state_force_bypass_during_cooldown(
+async def test_query_state_reads_while_the_loop_is_cooling_down(
     hass,
     sample_virtual_key,
     mock_ble_resolver,
     mock_ttlock_client,
 ) -> None:
-    """`force_cooldown_bypass=True` connects even while a cooldown is active."""
-    import time
+    """A poll still reaches the lock while the maintain loop waits out a drop.
 
+    Regression: the post-drop cooldown used to short-circuit every
+    coordinator poll, and the loop re-armed it on each drop, so the
+    configured `scan_interval` was silently never honoured.
+    """
     mock_ttlock_client.query_state = AsyncMock(return_value=(0, 90))
     conn = TtlockBleConnection(hass, sample_virtual_key)
-    conn._cooldown_until = time.monotonic() + 60.0
-    assert await conn.async_query_state(force_cooldown_bypass=True) == (0, 90)
-
-
-async def test_query_state_short_circuits_during_cooldown(
-    hass,
-    sample_virtual_key,
-    mock_ble_resolver,
-    mock_ttlock_client,
-) -> None:
-    """While `_cooldown_until` is in the future, queries return None without BLE I/O."""
-    import time
-
-    conn = TtlockBleConnection(hass, sample_virtual_key)
-    conn._cooldown_until = time.monotonic() + 60.0
-    assert await conn.async_query_state() is None
-    mock_ble_resolver.assert_not_called()
-    mock_ttlock_client.connect.assert_not_awaited()
-
-
-async def test_lock_command_bypasses_cooldown(
-    hass,
-    sample_virtual_key,
-    mock_ble_resolver,
-    mock_ttlock_client,
-) -> None:
-    """User-initiated `async_lock` still tries to connect during cooldown."""
-    import time
-
-    conn = TtlockBleConnection(hass, sample_virtual_key)
-    conn._cooldown_until = time.monotonic() + 60.0
-    await conn.async_lock()
-    mock_ttlock_client.lock.assert_awaited_once()
+    with patch.multiple(
+        "custom_components.ttlock_ble.connection",
+        RECONNECT_INITIAL_BACKOFF=0.005,
+        RECONNECT_MAX_BACKOFF=0.01,
+        RECONNECT_COOLDOWN_SECONDS=30.0,
+    ):
+        await conn.async_start()
+        for _ in range(20):
+            await asyncio.sleep(0.005)
+            if mock_ttlock_client.connect.await_count >= 1:
+                break
+        conn._on_disconnected(mock_ttlock_client)
+        await asyncio.sleep(0.02)
+        assert await conn.async_query_state() == (0, 90)
+        await conn.async_stop()
 
 
 async def test_on_disconnected_wakes_maintain_loop(
@@ -325,21 +310,19 @@ async def test_on_disconnected_wakes_maintain_loop(
     assert conn._disconnected.is_set()
 
 
-async def test_maintain_loop_enters_cooldown_on_drop(
+async def test_maintain_loop_waits_before_reconnecting_after_a_drop(
     hass,
     sample_virtual_key,
     mock_ble_resolver,
     mock_ttlock_client,
 ) -> None:
-    """After any disconnect, the maintain loop sets `_cooldown_until` in the future."""
-    import time
-
+    """After a disconnect the loop sits out the cooldown instead of retrying."""
     conn = TtlockBleConnection(hass, sample_virtual_key)
     with patch.multiple(
         "custom_components.ttlock_ble.connection",
         RECONNECT_INITIAL_BACKOFF=0.005,
         RECONNECT_MAX_BACKOFF=0.01,
-        RECONNECT_COOLDOWN_SECONDS=5.0,
+        RECONNECT_COOLDOWN_SECONDS=30.0,
     ):
         await conn.async_start()
         # Let the loop connect and arm `_disconnected.wait()`.
@@ -347,13 +330,11 @@ async def test_maintain_loop_enters_cooldown_on_drop(
             await asyncio.sleep(0.005)
             if mock_ttlock_client.connect.await_count >= 1:
                 break
-        # Trigger a drop; the loop should enter cooldown next tick.
+        connects_before_drop = mock_ttlock_client.connect.await_count
+        mock_ttlock_client.is_connected = False
         conn._on_disconnected(mock_ttlock_client)
-        for _ in range(20):
-            await asyncio.sleep(0.005)
-            if conn._cooldown_until > 0:
-                break
-        assert conn._cooldown_until > time.monotonic()
+        await asyncio.sleep(0.05)
+        assert mock_ttlock_client.connect.await_count == connects_before_drop
         await conn.async_stop()
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -88,3 +88,58 @@ async def test_coordinator_polls_every_connection_once(
     assert set(data) == set(conns)
     for conn in conns.values():
         conn.async_query_state.assert_awaited_once()
+
+
+def _advertisement(*, unlocked: bool, battery: int = 66):
+    from ttlock_ble import LockAdvertisement, LockState
+
+    return LockAdvertisement(
+        protocol_type=5,
+        protocol_version=3,
+        scene=2,
+        lock_state=LockState.UNLOCKED if unlocked else LockState.LOCKED,
+        has_new_records=False,
+        is_setting_mode=False,
+        battery=battery,
+        lock_mac="AA:BB:CC:DD:EE:FF",
+    )
+
+
+async def test_apply_advertisement_publishes_state_without_polling(
+    hass,
+    sample_virtual_key,
+) -> None:
+    conn = _mock_connection()
+    coordinator = _coordinator(hass, {sample_virtual_key.lockMac: conn})
+    coordinator.async_apply_advertisement(
+        sample_virtual_key.lockMac,
+        _advertisement(unlocked=True, battery=66),
+    )
+    state = coordinator.data[sample_virtual_key.lockMac]
+    assert state["locked"] is False
+    assert state["battery_level"] == 66
+    assert state["available"] is True
+    conn.async_query_state.assert_not_awaited()
+
+
+async def test_apply_advertisement_keeps_the_other_locks(hass) -> None:
+    coordinator = _coordinator(hass, {})
+    coordinator.async_set_updated_data({"OTHER": {"available": False}})
+    coordinator.async_apply_advertisement(
+        "AA:BB:CC:DD:EE:FF", _advertisement(unlocked=False)
+    )
+    assert coordinator.data["OTHER"] == {"available": False}
+    assert coordinator.data["AA:BB:CC:DD:EE:FF"]["locked"] is True
+
+
+async def test_has_state_is_false_until_a_lock_state_is_known(hass) -> None:
+    coordinator = _coordinator(hass, {})
+    assert coordinator.async_has_state("AA:BB:CC:DD:EE:FF") is False
+    coordinator.async_set_updated_data(
+        {"AA:BB:CC:DD:EE:FF": {"locked": None, "available": False}},
+    )
+    assert coordinator.async_has_state("AA:BB:CC:DD:EE:FF") is False
+    coordinator.async_apply_advertisement(
+        "AA:BB:CC:DD:EE:FF", _advertisement(unlocked=False)
+    )
+    assert coordinator.async_has_state("AA:BB:CC:DD:EE:FF") is True

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -62,3 +62,70 @@ async def test_diagnostics_includes_coordinator_state(
 async def test_diagnostics_options_block_is_a_dict(hass, setup_integration) -> None:
     diag = await async_get_config_entry_diagnostics(hass, setup_integration)
     assert isinstance(diag["entry"]["options"], dict)
+
+
+async def test_diagnostics_reports_no_advertisement_when_unseen(
+    hass,
+    setup_integration,
+    sample_virtual_key,
+) -> None:
+    from custom_components.ttlock_ble.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, setup_integration)
+    assert diagnostics["advertisements"][sample_virtual_key.lockMac] is None
+
+
+async def test_diagnostics_carries_the_raw_advertisement_bytes(
+    hass,
+    setup_integration,
+    sample_virtual_key,
+) -> None:
+    """The dump keeps the raw payload so an undecodable layout stays diagnosable."""
+    from unittest.mock import MagicMock, patch
+
+    from custom_components.ttlock_ble.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+
+    payload = bytes([2, 0x01, 77, 0, 0, 0, 0]) + bytes.fromhex("ffeeddccbbaa")
+    service_info = MagicMock()
+    service_info.source = "hci0"
+    service_info.rssi = -61
+    service_info.manufacturer_data = {0x0305: payload}
+    with patch(
+        "custom_components.ttlock_ble.diagnostics.async_last_service_info",
+        return_value=service_info,
+    ):
+        diagnostics = await async_get_config_entry_diagnostics(hass, setup_integration)
+
+    captured = diagnostics["advertisements"][sample_virtual_key.lockMac]
+    assert captured["rssi"] == -61
+    assert captured["manufacturer_data"] == {"773": payload.hex()}
+    assert captured["decoded"]["lock_state"] == "UNLOCKED"
+    assert captured["decoded"]["battery"] == 77
+
+
+async def test_diagnostics_decoded_is_none_for_a_foreign_payload(
+    hass,
+    setup_integration,
+    sample_virtual_key,
+) -> None:
+    from unittest.mock import MagicMock, patch
+
+    from custom_components.ttlock_ble.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+
+    service_info = MagicMock()
+    service_info.source = "hci0"
+    service_info.rssi = -80
+    service_info.manufacturer_data = {0x004C: b"\x02\x15"}
+    with patch(
+        "custom_components.ttlock_ble.diagnostics.async_last_service_info",
+        return_value=service_info,
+    ):
+        diagnostics = await async_get_config_entry_diagnostics(hass, setup_integration)
+
+    assert diagnostics["advertisements"][sample_virtual_key.lockMac]["decoded"] is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -61,7 +61,7 @@ async def test_setup_registers_bluetooth_callback_per_lock(
     assert len(setup_integration.runtime_data.bluetooth_unsubs) == 1
 
 
-async def test_bluetooth_callback_triggers_coordinator_refresh(
+async def test_bluetooth_callback_polls_while_no_state_is_known(
     hass,
     sample_stored_key,
     enable_bluetooth,
@@ -69,12 +69,14 @@ async def test_bluetooth_callback_triggers_coordinator_refresh(
     mock_cloud,
     mock_ttlock_connection,
 ) -> None:
-    from unittest.mock import MagicMock, patch
+    """An advertisement we cannot decode still bootstraps the first reading."""
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     from pytest_homeassistant_custom_component.common import MockConfigEntry
 
     from custom_components.ttlock_ble.const import DOMAIN
 
+    mock_ttlock_connection.async_query_state = AsyncMock(return_value=None)
     captured_callbacks: list = []
 
     def _capture(hass_arg, callback, matcher, mode):
@@ -82,7 +84,7 @@ async def test_bluetooth_callback_triggers_coordinator_refresh(
         return MagicMock()  # the unsub function
 
     with patch(
-        "custom_components.ttlock_ble.async_register_callback",
+        "custom_components.ttlock_ble.advertisement.async_register_callback",
         side_effect=_capture,
     ):
         entry = MockConfigEntry(
@@ -95,10 +97,12 @@ async def test_bluetooth_callback_triggers_coordinator_refresh(
         await hass.async_block_till_done()
 
     assert len(captured_callbacks) == 1
+    service_info = MagicMock()
+    service_info.manufacturer_data = {}
     with patch.object(
         entry.runtime_data.coordinator, "async_request_refresh"
     ) as mocked_refresh:
-        captured_callbacks[0](MagicMock(), MagicMock())
+        captured_callbacks[0](service_info, MagicMock())
         await hass.async_block_till_done()
         mocked_refresh.assert_called()
 
@@ -119,7 +123,7 @@ async def test_unload_invokes_bluetooth_unsubs(
 
     fake_unsub = MagicMock()
     with patch(
-        "custom_components.ttlock_ble.async_register_callback",
+        "custom_components.ttlock_ble.advertisement.async_register_callback",
         return_value=fake_unsub,
     ):
         entry = MockConfigEntry(

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -134,7 +134,7 @@ async def test_async_unlock_sets_optimistic_state(
 
     initial = hass.states.async_all("lock")[0]
     assert initial.state == "locked"
-    # Simulate cooldown for the post-command refresh.
+    # The post-command refresh finds the lock out of range.
     mock_ttlock_connection.async_query_state = AsyncMock(return_value=None)
     await hass.services.async_call(
         LOCK_DOMAIN,
@@ -176,7 +176,7 @@ async def test_async_lock_sets_optimistic_state(
     await hass.async_block_till_done()
     state = hass.states.async_all("lock")[0]
     assert state.state == "unlocked"
-    # Simulate cooldown for the post-command refresh.
+    # The post-command refresh finds the lock out of range.
     mock_ttlock_connection.async_query_state = AsyncMock(return_value=None)
     await hass.services.async_call(
         LOCK_DOMAIN,
@@ -252,9 +252,7 @@ async def test_lock_event_triggers_state_refresh(
     )
     await hass.async_block_till_done()
     assert hass.states.get(state.entity_id).state == "unlocked"
-    mock_ttlock_connection.async_query_state.assert_awaited_with(
-        force_cooldown_bypass=True
-    )
+    mock_ttlock_connection.async_query_state.assert_awaited()
 
 
 async def test_lock_event_with_decoded_state_skips_query(
@@ -375,9 +373,7 @@ async def test_lock_event_forced_query_returns_none_keeps_state(
         LockEvent(cmd_echo=0x47, status=1, data=b""),
     )
     await hass.async_block_till_done()
-    mock_ttlock_connection.async_query_state.assert_awaited_with(
-        force_cooldown_bypass=True,
-    )
+    mock_ttlock_connection.async_query_state.assert_awaited()
     assert hass.states.get(state.entity_id).state == "locked"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1116,7 +1116,7 @@ wheels = [
 
 [[package]]
 name = "ha-ttlock-ble"
-version = "3.2.1"
+version = "3.2.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -1158,7 +1158,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.332" },
     { name = "serialx", specifier = "==1.8.2" },
-    { name = "ttlock-ble", specifier = "==0.1.7" },
+    { name = "ttlock-ble", specifier = "==0.1.8" },
 ]
 lint = [
     { name = "mypy", specifier = "==2.3.0" },
@@ -2795,7 +2795,7 @@ wheels = [
 
 [[package]]
 name = "ttlock-ble"
-version = "0.1.7"
+version = "0.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
@@ -2805,9 +2805,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/b4/1e3e6d2a4ddf1aea653b09e65d7b6e54f49c24bc2df985e8cb9d489667b2/ttlock_ble-0.1.7.tar.gz", hash = "sha256:1550f3fba8b8f07e1e6aa25d1c4612d846252f444551632d7c6fa654b1a5a851", size = 113707, upload-time = "2026-05-25T22:55:40.21Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/38/79d0d62b1df9f554353fd7a418f7171b72a925cd6ad2c06cbaa3f54b95ec/ttlock_ble-0.1.8.tar.gz", hash = "sha256:a1d4b43812710a9627d3132c05cdf2dd2319b4a4d4bfb816b100ccf5d620724b", size = 128980, upload-time = "2026-07-29T18:04:11.336Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/d8/30aecc5d0b07845e26f8df7181c69c5b01700ad631f1dfb0898223812214/ttlock_ble-0.1.7-py3-none-any.whl", hash = "sha256:227950fc8060f85243d8849a9d00b86a970e4c433878649edc467b1b9056432a", size = 43486, upload-time = "2026-05-25T22:55:39.19Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a8/88a6fb363979249e65744a0f123fc7ee0f5e340721f9775c0847b90968d8/ttlock_ble-0.1.8-py3-none-any.whl", hash = "sha256:9f6b8441583e9af70f78c75fd8acc80ed8bac27fa735696947ba8108a2a13c86", size = 45496, upload-time = "2026-07-29T18:04:10.244Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #42

## The problem

The lock state stopped following anything that happened out of band: an auto-lock, an operation from the official app, a code typed on the keypad. Home Assistant kept showing whatever it had last seen, sometimes for an hour.

Two causes, both addressed here.

**1. The cooldown was vetoing the polls.** After any BLE drop the connection entered a cooldown before reconnecting — sound in itself, but the same timer also short-circuited `async_query_state`. Since the firmware drops any idle session within seconds, every session ended by re-arming the cooldown, and the configured `scan_interval` never actually reached the lock. Setting it to the 60 s minimum changed nothing.

**2. The state was already arriving and being discarded.** Every advertisement triggered a coordinator refresh — which the cooldown then swallowed — while the advertisement itself carries the bolt position and the battery level in its manufacturer data. In the logs attached to the issue, the reading was in hand at the exact moment the auto-lock fired.

## The fix

`TtlockBleAdvertisementTracker` decodes the advertisements Home Assistant's bluetooth manager already receives and publishes the state directly, costing no BLE session. This is the **only** channel that can report an auto-lock: the firmware writes no operation-log record for it, and by the time it fires the lock has no open connection left to push an event on.

The cooldown now paces the reconnect loop only. Reads are rate-limited by their own callers — the coordinator by `scan_interval`, the lock entity by the user pressing a button — so `scan_interval` means what it says again.

An advertisement that decodes also postpones the next poll, so a lock in range is rarely connected to just to be read; the effect on the lock's battery is a reduction, not an increase. One that cannot be decoded still falls back to a refresh, but only while no state is known yet — refreshing on every advertisement is what made the cooldown look necessary in the first place.

`iot_class` moves from `local_polling` to `local_push` accordingly.

## Diagnosability

The advertisement layout varies across lock families, and the pre-V3 and V2S ones carry no state byte at all. Rather than guess from a log, the diagnostics dump now includes the last advertisement seen per lock — raw bytes included, with `decoded: null` when the payload does not match the layout we know. A "state never updates" report is now answerable from the dump alone.

The decoded trailing address must match the lock's MAC before the state is trusted: a payload long enough to decode is not proof that it came from a lock.

## Notes

- Requires `ttlock-ble` 0.1.8, which adds the `LockAdvertisement` decoder. Both pins (`manifest.json` and the dev group) are bumped.
- Tests cover the decoder wiring, the MAC mismatch path, the poll fallback, and the regression on the cooldown. Suite at 180 tests, 99.78% coverage.