### PR TITLE
feat(config-flow): add a lock key by hand, without a cloud account

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ The integration follows the HA `DataUpdateCoordinator` pattern:
 ```
 config_flow.py   → cloud-bootstraps credentials, requests 2FA when needed,
                     pulls the per-lock VirtualKeys, creates the ConfigEntry
+manual_key.py    → builds a VirtualKey from a hand-entered key, for locks
+                    that were never in a TTLock account
 __init__.py      → instantiates one TtlockBleConnection per lock and a
                     DataUpdateCoordinator, performs the first refresh
 connection.py    → owns the long-lived BLE session, reconnect loop,
@@ -71,12 +73,27 @@ event.py         → EventEntity that surfaces decoded LockEvent pushes
 
 ### Config flow surface
 
-`config_flow.py` implements five user-facing steps, all sharing one module-level `_credentials_schema` builder:
+`config_flow.py` implements the user-facing steps, sharing one module-level `_credentials_schema` builder for the credential ones and one `_manual_key_schema` for the manual one:
 
-- `async_step_user` — initial setup; sets unique_id from username, aborts on duplicate. Branches to `async_step_verify_code` when the cloud rejects the login with the 2FA "new device" error code.
+- `async_step_user` — a menu, nothing else: the entry can come from a cloud account or from a key entered by hand.
+- `async_step_cloud` — the credential step (named `user` before the menu existed); sets unique_id from username, aborts on duplicate. Branches to `async_step_verify_code` when the cloud rejects the login with the 2FA "new device" error code.
 - `async_step_verify_code` — second step of the 2FA branch; submits the emailed code via `_async_validate_code_and_login` and finalizes entry creation on success.
 - `async_step_reauth` / `async_step_reauth_confirm` — HA's reauth entry points. Nothing in this integration currently raises `ConfigEntryAuthFailed` to trigger them automatically — the coordinator and `connection.py` only ever talk BLE after setup, never the cloud again — so today these steps are reachable only by manually starting a reauth flow for the entry. `async_update_reload_and_abort` rotates credentials in place on success.
-- `async_step_reconfigure` — lets the user edit credentials via the integration's three-dot menu, no delete-and-re-add cycle.
+- `async_step_manual` — takes a key obtained outside the cloud (see below); unique_id is the lock's MAC.
+- `async_step_reconfigure` — lets the user edit credentials via the integration's three-dot menu, no delete-and-re-add cycle. **Branches on how the entry was created**: an entry with no `username` has no account to re-prompt for, so it goes to `async_step_reconfigure_manual` and re-opens the key form pre-filled instead.
+
+### Manual key entry
+
+`manual_key.py` defines `TtlockBleManualKey`, for locks initialised by a local BLE bridge and never registered in a TTLock account. It asks only for what reaches the wire — MAC, AES key, unlock key, optional admin passcode, and the five frame-header integers — because the rest of what the cloud returns per key is never read: `payload_check_user_time()` is called with no arguments, so uid and lockFlagPos go out zeroed and the dates are the firmware's "permanent key" literals whatever the validity window said.
+
+Four things are load-bearing:
+
+- **The unlock key and admin passcode are stored verbatim.** The cloud path runs them through `decode_password()`; a locally obtained one is already plain, and decoding it again would corrupt it.
+- **The AES key is normalised to continuous hex on save.** The form accepts more separators than the library's `hex_key_to_bytes` parses (which takes comma, dot or continuous only), so a space-separated paste would be accepted and then fail at the first connection.
+- **The advertisement cross-checks the frame header.** Protocol type, version and scene are compared against what the lock broadcasts when it is in range, turning a typo into a form error instead of a lock that never answers. `group_id`/`org_id` are not in the advertisement and cannot be checked this way.
+- **A lock already held by another entry is rejected.** `_abort_if_lock_configured` scans the stored keys of every entry, because a cloud entry's unique id is the account, not the MAC — without it the same lock could be added twice and the second entry would silently collide on entity unique ids and get no entities.
+
+`username`/`password` are `NotRequired` on `TtlockBleConfigData` for exactly this reason; anything reading them must cope with their absence.
 
 `async_step_reauth_confirm` and `async_step_reconfigure` both funnel through the shared `_async_step_credentials_for_entry` body (login, then `async_update_reload_and_abort`); `async_get_options_flow` returns `TtlockBleOptionsFlow` from `options_flow.py` (one class per file).
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Local control of TTLock smart locks over Bluetooth, for [Home Assistant](https:/
 - **Real-time push events** — keypad presses, fingerprint reads, IC-card swipes, mechanical key turns, and auto-lock fires arrive as Home Assistant events the moment the lock emits them.
 - **Battery sensor** — diagnostic entity refreshed by every poll *and* every push, no extra BLE traffic.
 - **2FA-aware config flow** — handles TTLock's "new device" verification by emailing a one-time code and prompting for it.
+- **Works without a cloud account** — a lock initialised locally can be added by entering its key directly, no TTLock account involved at any point.
 - **Passive state tracking** — the bolt position and battery level are read from the lock's own BLE advertisements, with no connection and no battery cost. This is what catches an auto-lock or an operation done from the official app.
 - **Persistent BLE session with a post-drop cooldown** — keeps the link warm to receive push events, and waits before reconnecting so a lock in idle-sleep isn't thrashed.
 - **Reauth + reconfigure** — re-prompt for credentials in place when the cloud rejects the cached login, or edit them via the integration's three-dot menu.
@@ -36,9 +37,26 @@ Each configured lock produces one HA device with three entities:
 1. Install via HACS using the button above, or add this repo as a custom HACS repository (category: Integration).
 2. Restart Home Assistant.
 3. Settings → Devices & Services → Add Integration → **TTLock BLE**.
-4. Enter the TTLock cloud email + password you use in the official app.
-5. If TTLock has never seen this Home Assistant before, it will email a verification code — paste it into the next step.
-6. The integration syncs every lock visible on the account and creates the entities. From this point on, all lock / unlock / state operations stay on Bluetooth.
+4. Choose how the keys are obtained:
+   - **Sign in to a TTLock account** — enter the email + password you use in the official app. If TTLock has never seen this Home Assistant before it emails a verification code; paste it into the next step. Every lock on the account is synced at once.
+   - **Enter a lock key manually** — for a lock initialised outside the cloud. See below.
+5. From this point on, all lock / unlock / state operations stay on Bluetooth.
+
+### Adding a lock without a TTLock account
+
+A lock initialised by a local BLE bridge never goes through the cloud, and its owner already holds what Bluetooth needs. That key can be entered directly, one lock per entry:
+
+| Field | Notes |
+|---|---|
+| Lock MAC address | `AA:BB:CC:DD:EE:FF` |
+| AES key | 16 bytes, continuous hex or separated (`2c,3d,…`) |
+| Unlock key | digits, entered verbatim — not the obfuscated form the cloud returns |
+| Admin passcode | optional, digits; only needed for managing passcodes |
+| Protocol type / version / scene / group ID / organisation ID | the frame header the lock expects. The defaults (5, 3, 2, 1, 1) suit most V3 locks |
+
+Only these reach the wire. The rest of what the cloud returns per key — user id, lock-flag position, validity window — is never read by the Bluetooth layer, which addresses the lock with a zeroed user id and the firmware's "permanent key" date literals regardless.
+
+If the lock is in range when the form is submitted, the protocol type, version and scene are checked against what it broadcasts, so a wrong value is caught there instead of becoming a lock that never answers. Getting a value wrong later is fixable through the integration's three-dot menu → **Reconfigure**.
 
 The Bluetooth radio HA already manages (USB dongle, built-in adapter, or proxy) discovers the lock automatically — no additional configuration.
 
@@ -88,7 +106,8 @@ custom_components/ttlock_ble/
 ├── advertisement.py   # TtlockBleAdvertisementTracker: state from advertisements
 ├── api.py             # TtlockBleApiClient: TTLockCloud wrapper (cloud bootstrap only)
 ├── brand/             # icon / logo PNGs (local placeholder for HA brand registry)
-├── config_flow.py     # user / verify_code / reauth_confirm / reconfigure steps
+├── config_flow.py     # menu / cloud / manual / verify_code / reauth / reconfigure
+├── manual_key.py      # TtlockBleManualKey: key entry for cloud-less locks
 ├── connection.py      # TtlockBleConnection: persistent BLE session per lock
 ├── const.py           # DOMAIN, LOGGER, defaults
 ├── coordinator.py     # DataUpdateCoordinator polling each connection

--- a/custom_components/ttlock_ble/config_flow.py
+++ b/custom_components/ttlock_ble/config_flow.py
@@ -8,7 +8,9 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers import selector
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util import slugify
 
@@ -20,6 +22,7 @@ from .exceptions import (
     TtlockBleApiClientError,
     TtlockBleApiClientVerificationRequiredError,
 )
+from .manual_key import TtlockBleManualKey
 from .options_flow import TtlockBleOptionsFlow
 
 if TYPE_CHECKING:
@@ -29,12 +32,19 @@ if TYPE_CHECKING:
         TtlockBleConfigData,
         TtlockBleConfigEntry,
         TtlockBleCredentialsInput,
+        TtlockBleManualKeyInput,
         TtlockBleStoredKey,
         TtlockBleVerificationInput,
     )
 
 
 CONF_VERIFICATION_CODE = "verification_code"
+ABORT_ALREADY_CONFIGURED = "already_configured"
+DEFAULT_PROTOCOL_TYPE = 5
+DEFAULT_PROTOCOL_VERSION = 3
+DEFAULT_SCENE = 2
+DEFAULT_GROUP_ID = 1
+DEFAULT_ORG_ID = 1
 
 
 def _credentials_schema(default_username: str | None = None) -> vol.Schema:
@@ -53,6 +63,82 @@ def _credentials_schema(default_username: str | None = None) -> vol.Schema:
                 selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD),
             ),
         },
+    )
+
+
+def _manual_key_schema(
+    defaults: TtlockBleManualKeyInput | None = None,
+) -> vol.Schema:
+    """Build the manual key schema, pre-filled when correcting a rejected form."""
+    previous = cast("Mapping[str, str | int]", defaults or {})
+
+    def _default(field: str, fallback: str | int) -> str | int:
+        return previous.get(field, fallback)
+
+    return vol.Schema(
+        {
+            vol.Required("lock_mac", default=_default("lock_mac", "")): (
+                selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
+                )
+            ),
+            vol.Required("aes_key", default=_default("aes_key", "")): (
+                selector.TextSelector(
+                    selector.TextSelectorConfig(
+                        type=selector.TextSelectorType.PASSWORD,
+                    ),
+                )
+            ),
+            vol.Required("unlock_key", default=_default("unlock_key", "")): (
+                selector.TextSelector(
+                    selector.TextSelectorConfig(
+                        type=selector.TextSelectorType.PASSWORD,
+                    ),
+                )
+            ),
+            vol.Optional("admin_passcode", default=_default("admin_passcode", "")): (
+                selector.TextSelector(
+                    selector.TextSelectorConfig(
+                        type=selector.TextSelectorType.PASSWORD,
+                    ),
+                )
+            ),
+            vol.Optional("lock_name", default=_default("lock_name", "")): (
+                selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
+                )
+            ),
+            vol.Required(
+                "protocol_type",
+                default=_default("protocol_type", DEFAULT_PROTOCOL_TYPE),
+            ): _positive_int_selector(),
+            vol.Required(
+                "protocol_version",
+                default=_default("protocol_version", DEFAULT_PROTOCOL_VERSION),
+            ): _positive_int_selector(),
+            vol.Required("scene", default=_default("scene", DEFAULT_SCENE)): (
+                _positive_int_selector()
+            ),
+            vol.Required(
+                "group_id",
+                default=_default("group_id", DEFAULT_GROUP_ID),
+            ): _positive_int_selector(),
+            vol.Required("org_id", default=_default("org_id", DEFAULT_ORG_ID)): (
+                _positive_int_selector()
+            ),
+        },
+    )
+
+
+def _positive_int_selector() -> selector.NumberSelector:
+    """Build the numeric selector used by every frame-header field."""
+    return selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            min=0,
+            max=255,
+            step=1,
+            mode=selector.NumberSelectorMode.BOX,
+        ),
     )
 
 
@@ -88,6 +174,13 @@ class TtlockBleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     # strict LSP compliance for stronger typing of our own user_input schema.
     async def async_step_user(  # type: ignore[override]
         self,
+        user_input: TtlockBleCredentialsInput | None = None,  # noqa: ARG002
+    ) -> config_entries.ConfigFlowResult:
+        """Offer the two ways of obtaining a lock's keys."""
+        return self.async_show_menu(step_id="user", menu_options=["cloud", "manual"])
+
+    async def async_step_cloud(
+        self,
         user_input: TtlockBleCredentialsInput | None = None,
     ) -> config_entries.ConfigFlowResult:
         """Collect credentials and either create the entry or branch to 2FA."""
@@ -103,10 +196,37 @@ class TtlockBleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if errors.get("base") == "verification_required":
                 return await self.async_step_verify_code()
         return self.async_show_form(
-            step_id="user",
+            step_id="cloud",
             data_schema=_credentials_schema(
                 default_username=user_input["username"] if user_input else None,
             ),
+            errors=errors,
+        )
+
+    async def async_step_manual(
+        self,
+        user_input: TtlockBleManualKeyInput | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Take a key obtained outside the cloud and create the entry from it."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            manual_key = TtlockBleManualKey(self.hass)
+            errors = manual_key.async_validate(user_input)
+            if not errors:
+                key = manual_key.build(user_input)
+                await self.async_set_unique_id(format_mac(key.lockMac))
+                self._abort_if_unique_id_configured()
+                self._abort_if_lock_configured(key.lockMac)
+                data: TtlockBleConfigData = {
+                    "keys": [cast("TtlockBleStoredKey", key.to_dict())],
+                }
+                return self.async_create_entry(
+                    title=key.lockAlias,
+                    data=dict(data),
+                )
+        return self.async_show_form(
+            step_id="manual",
+            data_schema=_manual_key_schema(user_input),
             errors=errors,
         )
 
@@ -151,13 +271,62 @@ class TtlockBleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self,
         user_input: TtlockBleCredentialsInput | None = None,
     ) -> config_entries.ConfigFlowResult:
-        """Allow editing credentials of an existing entry."""
+        """Allow editing an existing entry, by whichever route created it."""
         entry = self._get_reconfigure_entry()
+        existing = cast("TtlockBleConfigData", cast("object", entry.data))
+        if "username" not in existing:
+            return await self.async_step_reconfigure_manual()
         return await self._async_step_credentials_for_entry(
             entry,
             step_id="reconfigure",
             user_input=user_input,
         )
+
+    async def async_step_reconfigure_manual(
+        self,
+        user_input: TtlockBleManualKeyInput | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Correct the key of an entry that was created from a manual one."""
+        entry = self._get_reconfigure_entry()
+        existing = cast("TtlockBleConfigData", cast("object", entry.data))
+        errors: dict[str, str] = {}
+        manual_key = TtlockBleManualKey(self.hass)
+        if user_input is not None:
+            errors = manual_key.async_validate(user_input)
+            if not errors:
+                key = manual_key.build(user_input)
+                data: TtlockBleConfigData = {
+                    "keys": [cast("TtlockBleStoredKey", key.to_dict())],
+                }
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates=dict(data),
+                    title=key.lockAlias,
+                )
+        return self.async_show_form(
+            step_id="reconfigure_manual",
+            data_schema=_manual_key_schema(
+                user_input or manual_key.defaults_from(existing["keys"][0]),
+            ),
+            errors=errors,
+        )
+
+    @callback
+    def _abort_if_lock_configured(self, lock_mac: str) -> None:
+        """
+        Abort when some existing entry already carries this lock.
+
+        The unique id alone does not catch it: an entry created from a
+        cloud account is keyed by the account, so the same lock arriving
+        by hand would otherwise be accepted and then collide on entity
+        unique ids, leaving the second entry silently without entities.
+        """
+        target = format_mac(lock_mac)
+        for entry in self._async_current_entries(include_ignore=False):
+            existing = cast("TtlockBleConfigData", cast("object", entry.data))
+            for key in existing.get("keys", []):
+                if format_mac(key["lockMac"]) == target:
+                    raise AbortFlow(ABORT_ALREADY_CONFIGURED)
 
     async def _async_step_credentials_for_entry(
         self,

--- a/custom_components/ttlock_ble/data/__init__.py
+++ b/custom_components/ttlock_ble/data/__init__.py
@@ -17,6 +17,7 @@ from .diagnostics_entry import TtlockBleDiagnosticsEntry
 from .diagnostics_lock_summary import TtlockBleDiagnosticsLockSummary
 from .diagnostics_payload import TtlockBleDiagnosticsPayload
 from .lock_state import TtlockBleLockState
+from .manual_key_input import TtlockBleManualKeyInput
 from .options_data import TtlockBleOptionsData
 from .runtime import TtlockBleData
 from .stored_key import TtlockBleStoredKey
@@ -42,6 +43,7 @@ __all__ = [
     "TtlockBleDiagnosticsLockSummary",
     "TtlockBleDiagnosticsPayload",
     "TtlockBleLockState",
+    "TtlockBleManualKeyInput",
     "TtlockBleOptionsData",
     "TtlockBleStoredKey",
     "TtlockBleStoredLockVersion",

--- a/custom_components/ttlock_ble/data/config_data.py
+++ b/custom_components/ttlock_ble/data/config_data.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 if TYPE_CHECKING:
     from .stored_key import TtlockBleStoredKey
 
 
 class TtlockBleConfigData(TypedDict):
-    """Shape of the credentials and key cache persisted on the config entry."""
+    """
+    Shape of the credentials and key cache persisted on the config entry.
 
-    username: str
-    password: str
+    `username`/`password` are absent on entries created from a manually
+    entered key: there is no cloud account behind those, so there is
+    nothing to re-authenticate against either.
+    """
+
+    username: NotRequired[str]
+    password: NotRequired[str]
     keys: list[TtlockBleStoredKey]

--- a/custom_components/ttlock_ble/data/manual_key_input.py
+++ b/custom_components/ttlock_ble/data/manual_key_input.py
@@ -1,0 +1,28 @@
+"""Shape of the manual key form, for locks initialised outside the TTLock cloud."""
+
+from __future__ import annotations
+
+from typing import NotRequired, TypedDict
+
+
+class TtlockBleManualKeyInput(TypedDict):
+    """
+    Shape of the manual key form, for locks initialised outside the TTLock cloud.
+
+    The five protocol integers are the frame header the firmware expects
+    (`protocol_type`, `protocol_version`, `scene`, `group_id`, `org_id`);
+    a lock rejects frames addressed with the wrong ones. `unlock_key` and
+    `admin_passcode` are taken verbatim — unlike the cloud payload, which
+    delivers them obfuscated.
+    """
+
+    lock_mac: str
+    aes_key: str
+    unlock_key: str
+    admin_passcode: NotRequired[str]
+    lock_name: NotRequired[str]
+    protocol_type: int
+    protocol_version: int
+    scene: int
+    group_id: int
+    org_id: int

--- a/custom_components/ttlock_ble/manual_key.py
+++ b/custom_components/ttlock_ble/manual_key.py
@@ -1,0 +1,184 @@
+"""Build a `VirtualKey` from the manual key form, for locks with no cloud account."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from homeassistant.components.bluetooth import async_last_service_info
+from homeassistant.helpers.device_registry import format_mac
+
+from ttlock_ble import LockAdvertisement, LockVersion, VirtualKey
+
+from .const import LOGGER
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .data import TtlockBleManualKeyInput, TtlockBleStoredKey
+
+_MAC_PATTERN = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
+_AES_KEY_BYTES = 16
+_AES_SEPARATORS = (",", ".", " ", "-")
+
+
+class TtlockBleManualKey:
+    """
+    Validate the manual key form and turn it into a `VirtualKey`.
+
+    A lock initialised outside the TTLock cloud — by a local BLE bridge,
+    for instance — leaves its owner holding exactly what Bluetooth needs
+    (the AES key, the unlock key, the admin passcode) and no account to
+    download it from. This is the path for those locks.
+
+    Only a handful of the cloud's fields ever reach the wire, so only
+    those are asked for. The rest of `VirtualKey` is padding the BLE
+    layer never reads: `CHECK_USER_TIME` is sent with a zeroed uid and
+    lock-flag position and the firmware's "permanent key" date literals,
+    whatever the cloud happened to say.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Bind to the HA instance whose bluetooth manager is cross-checked."""
+        self._hass = hass
+
+    def async_validate(self, user_input: TtlockBleManualKeyInput) -> dict[str, str]:
+        """Return per-field errors for the form, empty when the input is usable."""
+        errors: dict[str, str] = {}
+        if not _MAC_PATTERN.match(user_input["lock_mac"].strip()):
+            errors["lock_mac"] = "invalid_mac"
+        if _aes_key_bytes(user_input["aes_key"]) is None:
+            errors["aes_key"] = "invalid_aes_key"
+        if not user_input["unlock_key"].strip().isdigit():
+            errors["unlock_key"] = "invalid_unlock_key"
+        admin_passcode = (user_input.get("admin_passcode") or "").strip()
+        if admin_passcode and not admin_passcode.isdigit():
+            errors["admin_passcode"] = "invalid_admin_passcode"
+        if "lock_mac" not in errors:
+            errors.update(self._async_check_against_advertisement(user_input))
+        return errors
+
+    def build(self, user_input: TtlockBleManualKeyInput) -> VirtualKey:
+        """
+        Assemble the `VirtualKey` a validated form describes.
+
+        The AES key is stored as continuous hex rather than however it
+        was pasted: the form accepts more separators than the BLE layer
+        parses, and a key it cannot read would only fail at the first
+        connection, long after the entry looked healthy.
+        """
+        mac = user_input["lock_mac"].strip().replace("-", ":").upper()
+        name = (user_input.get("lock_name") or "").strip() or f"TTLock {mac}"
+        aes_key = _aes_key_bytes(user_input["aes_key"])
+        if aes_key is None:
+            msg = "build() requires input that async_validate accepted"
+            raise ValueError(msg)
+        return VirtualKey(
+            keyId=0,
+            lockId=0,
+            lockMac=mac,
+            lockAlias=name,
+            lockName=name,
+            lockVersion=LockVersion(
+                protocolType=int(user_input["protocol_type"]),
+                protocolVersion=int(user_input["protocol_version"]),
+                scene=int(user_input["scene"]),
+                groupId=int(user_input["group_id"]),
+                orgId=int(user_input["org_id"]),
+            ),
+            aesKeyStr=aes_key.hex(),
+            unlockKey=user_input["unlock_key"].strip(),
+            lockFlagPos=0,
+            timezoneRawOffSet=0,
+            adminPs=(user_input.get("admin_passcode") or "").strip(),
+        )
+
+    @staticmethod
+    def defaults_from(stored_key: TtlockBleStoredKey) -> TtlockBleManualKeyInput:
+        """Project a stored key back onto the form, for reconfiguring one."""
+        return {
+            "lock_mac": stored_key["lockMac"],
+            "aes_key": stored_key["aesKeyStr"],
+            "unlock_key": stored_key["unlockKey"],
+            "admin_passcode": stored_key["adminPs"],
+            "lock_name": stored_key["lockAlias"],
+            "protocol_type": stored_key["lockVersion"]["protocolType"],
+            "protocol_version": stored_key["lockVersion"]["protocolVersion"],
+            "scene": stored_key["lockVersion"]["scene"],
+            "group_id": stored_key["lockVersion"]["groupId"],
+            "org_id": stored_key["lockVersion"]["orgId"],
+        }
+
+    def _async_check_against_advertisement(
+        self,
+        user_input: TtlockBleManualKeyInput,
+    ) -> dict[str, str]:
+        """
+        Compare the entered frame header against what the lock advertises.
+
+        The lock broadcasts its own protocol type, version and scene, so
+        when it is in range those three can be checked before the entry
+        is created rather than failing later as a lock that never
+        answers. Silent when the lock has not been seen — being out of
+        range is not an error.
+        """
+        advertised = self._async_advertised(user_input["lock_mac"].strip())
+        if advertised is None:
+            return {}
+        entered = (
+            int(user_input["protocol_type"]),
+            int(user_input["protocol_version"]),
+            int(user_input["scene"]),
+        )
+        broadcast = (
+            advertised.protocol_type,
+            advertised.protocol_version,
+            advertised.scene,
+        )
+        if entered == broadcast:
+            return {}
+        LOGGER.warning(
+            "Manual key for %s declares protocol %d.%d scene %d, "
+            "but the lock advertises %d.%d scene %d",
+            user_input["lock_mac"],
+            *entered,
+            *broadcast,
+        )
+        return {"base": "protocol_mismatch"}
+
+    def _async_advertised(self, mac: str) -> LockAdvertisement | None:
+        """Decode the last advertisement seen for `mac`, if any."""
+        service_info = async_last_service_info(self._hass, mac, connectable=False)
+        if service_info is None:
+            return None
+        expected = format_mac(mac)
+        for company_id, payload in service_info.manufacturer_data.items():
+            advertisement = LockAdvertisement.from_manufacturer_data(
+                company_id,
+                payload,
+            )
+            if (
+                advertisement is not None
+                and format_mac(advertisement.lock_mac) == expected
+            ):
+                return advertisement
+        return None
+
+
+def _aes_key_bytes(raw: str) -> bytes | None:
+    """
+    Parse the AES key the way the BLE layer will, or `None` if it cannot.
+
+    Mirrors the library's own accepted forms — separated or continuous
+    hex — so a key is rejected in the form rather than at the first
+    connection attempt.
+    """
+    text = raw.strip()
+    for separator in _AES_SEPARATORS:
+        text = text.replace(separator, "")
+    if len(text) != _AES_KEY_BYTES * 2:
+        return None
+    try:
+        return bytes.fromhex(text)
+    except ValueError:
+        return None

--- a/custom_components/ttlock_ble/translations/en.json
+++ b/custom_components/ttlock_ble/translations/en.json
@@ -1,93 +1,138 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "title": "Set up TTLock BLE",
-                "description": "Enter your TTLock cloud credentials. They are used once to download the per-lock keys; after that, lock/unlock runs offline over Bluetooth.",
-                "data": {
-                    "username": "Email",
-                    "password": "Password"
-                }
-            },
-            "verify_code": {
-                "title": "Verify your TTLock account",
-                "description": "TTLock sent a one-time code to your email. Enter it below to register this Home Assistant install as a trusted device.",
-                "data": {
-                    "verification_code": "Verification code"
-                }
-            },
-            "reauth_confirm": {
-                "title": "Re-authenticate TTLock BLE",
-                "description": "Your credentials are no longer valid. Enter the updated credentials.",
-                "data": {
-                    "username": "Email",
-                    "password": "Password"
-                }
-            },
-            "reconfigure": {
-                "title": "Reconfigure TTLock BLE",
-                "description": "Update the credentials for this entry. Keys will be re-synced from the cloud.",
-                "data": {
-                    "username": "Email",
-                    "password": "Password"
-                }
-            }
-        },
-        "error": {
-            "auth": "Email or password is incorrect.",
-            "connection": "Unable to reach the TTLock cloud.",
-            "invalid_code": "The verification code was not accepted. Please try again.",
-            "verification_required": "TTLock requires verifying this device. Re-add the integration to complete the flow.",
-            "unknown": "Unknown error occurred."
-        },
-        "abort": {
-            "already_configured": "This account is already configured.",
-            "reauth_successful": "Re-authentication was successful.",
-            "reconfigure_successful": "Reconfiguration was successful."
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up TTLock BLE",
+        "description": "Choose how this Home Assistant gets the keys for your locks.",
+        "menu_options": {
+          "cloud": "Sign in to a TTLock account",
+          "manual": "Enter a lock key manually"
         }
+      },
+      "cloud": {
+        "title": "Set up TTLock BLE",
+        "description": "Enter your TTLock cloud credentials. They are used once to download the per-lock keys; after that, lock/unlock runs offline over Bluetooth.",
+        "data": {
+          "username": "Email",
+          "password": "Password"
+        }
+      },
+      "manual": {
+        "title": "Enter a lock key manually",
+        "description": "For a lock initialised outside the TTLock cloud. Enter the values your local setup produced; they are stored on this entry and used directly over Bluetooth, with no account involved. The AES key accepts either continuous hex or separated bytes. The five protocol numbers form the frame header the lock expects — the defaults suit most V3 locks, and if the lock is in range the first three are checked against what it broadcasts.",
+        "data": {
+          "lock_mac": "Lock MAC address",
+          "aes_key": "AES key",
+          "unlock_key": "Unlock key",
+          "admin_passcode": "Admin passcode (optional)",
+          "lock_name": "Name (optional)",
+          "protocol_type": "Protocol type",
+          "protocol_version": "Protocol version",
+          "scene": "Scene",
+          "group_id": "Group ID",
+          "org_id": "Organisation ID"
+        }
+      },
+      "verify_code": {
+        "title": "Verify your TTLock account",
+        "description": "TTLock sent a one-time code to your email. Enter it below to register this Home Assistant install as a trusted device.",
+        "data": {
+          "verification_code": "Verification code"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate TTLock BLE",
+        "description": "Your credentials are no longer valid. Enter the updated credentials.",
+        "data": {
+          "username": "Email",
+          "password": "Password"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure TTLock BLE",
+        "description": "Update the credentials for this entry. Keys will be re-synced from the cloud.",
+        "data": {
+          "username": "Email",
+          "password": "Password"
+        }
+      },
+      "reconfigure_manual": {
+        "title": "Update the lock key",
+        "description": "Correct the values stored for this lock. No cloud account is involved.",
+        "data": {
+          "lock_mac": "Lock MAC address",
+          "aes_key": "AES key",
+          "unlock_key": "Unlock key",
+          "admin_passcode": "Admin passcode (optional)",
+          "lock_name": "Name (optional)",
+          "protocol_type": "Protocol type",
+          "protocol_version": "Protocol version",
+          "scene": "Scene",
+          "group_id": "Group ID",
+          "org_id": "Organisation ID"
+        }
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "title": "TTLock BLE options",
-                "description": "Tune polling and other behaviour for this entry.",
-                "data": {
-                    "scan_interval": "Polling interval (seconds)"
-                }
-            }
-        }
+    "error": {
+      "auth": "Email or password is incorrect.",
+      "connection": "Unable to reach the TTLock cloud.",
+      "invalid_code": "The verification code was not accepted. Please try again.",
+      "verification_required": "TTLock requires verifying this device. Re-add the integration to complete the flow.",
+      "unknown": "Unknown error occurred.",
+      "invalid_mac": "Enter a MAC address in the form AA:BB:CC:DD:EE:FF.",
+      "invalid_aes_key": "The AES key must be 16 bytes of hex.",
+      "invalid_unlock_key": "The unlock key must be digits only.",
+      "invalid_admin_passcode": "The admin passcode must be digits only.",
+      "protocol_mismatch": "The lock is broadcasting a different protocol type, version or scene than the one entered. Check the values against your lock data."
     },
-    "entity": {
-        "binary_sensor": {
-            "presence": {
-                "name": "Available"
-            }
-        },
-        "event": {
-            "log": {
-                "name": "Log",
-                "state_attributes": {
-                    "event_type": {
-                        "state": {
-                            "unlock": "Unlock",
-                            "lock": "Lock",
-                            "unlock_failed": "Unlock failed",
-                            "password_change": "Password change",
-                            "other": "Other"
-                        }
-                    }
-                }
-            }
-        },
-        "lock": {
-            "lock": {
-                "name": "Lock"
-            }
-        },
-        "sensor": {
-            "battery": {
-                "name": "Battery"
-            }
-        }
+    "abort": {
+      "already_configured": "This lock or account is already configured.",
+      "reauth_successful": "Re-authentication was successful.",
+      "reconfigure_successful": "Reconfiguration was successful."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "TTLock BLE options",
+        "description": "Tune polling and other behaviour for this entry.",
+        "data": {
+          "scan_interval": "Polling interval (seconds)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "presence": {
+        "name": "Available"
+      }
+    },
+    "event": {
+      "log": {
+        "name": "Log",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "unlock": "Unlock",
+              "lock": "Lock",
+              "unlock_failed": "Unlock failed",
+              "password_change": "Password change",
+              "other": "Other"
+            }
+          }
+        }
+      }
+    },
+    "lock": {
+      "lock": {
+        "name": "Lock"
+      }
+    },
+    "sensor": {
+      "battery": {
+        "name": "Battery"
+      }
+    }
+  }
 }

--- a/custom_components/ttlock_ble/translations/pt-BR.json
+++ b/custom_components/ttlock_ble/translations/pt-BR.json
@@ -1,93 +1,138 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "title": "Configurar TTLock BLE",
-                "description": "Informe suas credenciais do TTLock cloud. Elas são usadas uma única vez para baixar as chaves das fechaduras; depois disso, trancar/destrancar roda offline via Bluetooth.",
-                "data": {
-                    "username": "Email",
-                    "password": "Senha"
-                }
-            },
-            "verify_code": {
-                "title": "Verifique sua conta TTLock",
-                "description": "O TTLock enviou um código de uso único para o seu email. Informe-o abaixo para registrar este Home Assistant como um dispositivo confiável.",
-                "data": {
-                    "verification_code": "Código de verificação"
-                }
-            },
-            "reauth_confirm": {
-                "title": "Re-autenticar TTLock BLE",
-                "description": "Suas credenciais não são mais válidas. Informe as credenciais atualizadas.",
-                "data": {
-                    "username": "Email",
-                    "password": "Senha"
-                }
-            },
-            "reconfigure": {
-                "title": "Reconfigurar TTLock BLE",
-                "description": "Atualize as credenciais desta entrada. As chaves serão re-sincronizadas do cloud.",
-                "data": {
-                    "username": "Email",
-                    "password": "Senha"
-                }
-            }
-        },
-        "error": {
-            "auth": "Email ou senha incorretos.",
-            "connection": "Não foi possível conectar ao TTLock cloud.",
-            "invalid_code": "O código de verificação não foi aceito. Tente novamente.",
-            "verification_required": "O TTLock requer verificação deste dispositivo. Remova e adicione a integração novamente para completar o fluxo.",
-            "unknown": "Ocorreu um erro desconhecido."
-        },
-        "abort": {
-            "already_configured": "Esta conta já está configurada.",
-            "reauth_successful": "Re-autenticação concluída com sucesso.",
-            "reconfigure_successful": "Reconfiguração concluída com sucesso."
+  "config": {
+    "step": {
+      "user": {
+        "title": "Configurar TTLock BLE",
+        "description": "Escolha como este Home Assistant obtém as chaves das suas fechaduras.",
+        "menu_options": {
+          "cloud": "Entrar com uma conta TTLock",
+          "manual": "Inserir uma chave manualmente"
         }
+      },
+      "cloud": {
+        "title": "Configurar TTLock BLE",
+        "description": "Informe suas credenciais do TTLock cloud. Elas são usadas uma única vez para baixar as chaves das fechaduras; depois disso, trancar/destrancar roda offline via Bluetooth.",
+        "data": {
+          "username": "Email",
+          "password": "Senha"
+        }
+      },
+      "manual": {
+        "title": "Inserir uma chave manualmente",
+        "description": "Para uma fechadura inicializada fora da nuvem TTLock. Informe os valores que a sua configuração local gerou; eles ficam guardados nesta entrada e são usados direto por Bluetooth, sem nenhuma conta envolvida. A chave AES aceita hex contínuo ou bytes separados. Os cinco números de protocolo formam o cabeçalho de quadro que a fechadura espera — os padrões servem para a maioria das fechaduras V3 e, se ela estiver ao alcance, os três primeiros são conferidos contra o que ela anuncia.",
+        "data": {
+          "lock_mac": "Endereço MAC da fechadura",
+          "aes_key": "Chave AES",
+          "unlock_key": "Chave de destravamento",
+          "admin_passcode": "Senha de administrador (opcional)",
+          "lock_name": "Nome (opcional)",
+          "protocol_type": "Tipo de protocolo",
+          "protocol_version": "Versão do protocolo",
+          "scene": "Cena",
+          "group_id": "ID do grupo",
+          "org_id": "ID da organização"
+        }
+      },
+      "verify_code": {
+        "title": "Verifique sua conta TTLock",
+        "description": "O TTLock enviou um código de uso único para o seu email. Informe-o abaixo para registrar este Home Assistant como um dispositivo confiável.",
+        "data": {
+          "verification_code": "Código de verificação"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-autenticar TTLock BLE",
+        "description": "Suas credenciais não são mais válidas. Informe as credenciais atualizadas.",
+        "data": {
+          "username": "Email",
+          "password": "Senha"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigurar TTLock BLE",
+        "description": "Atualize as credenciais desta entrada. As chaves serão re-sincronizadas do cloud.",
+        "data": {
+          "username": "Email",
+          "password": "Senha"
+        }
+      },
+      "reconfigure_manual": {
+        "title": "Atualizar a chave da fechadura",
+        "description": "Corrija os valores guardados para esta fechadura. Nenhuma conta na nuvem está envolvida.",
+        "data": {
+          "lock_mac": "Endereço MAC da fechadura",
+          "aes_key": "Chave AES",
+          "unlock_key": "Chave de destravamento",
+          "admin_passcode": "Senha de administrador (opcional)",
+          "lock_name": "Nome (opcional)",
+          "protocol_type": "Tipo de protocolo",
+          "protocol_version": "Versão do protocolo",
+          "scene": "Cena",
+          "group_id": "ID do grupo",
+          "org_id": "ID da organização"
+        }
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "title": "Opções do TTLock BLE",
-                "description": "Ajuste polling e outros comportamentos desta entrada.",
-                "data": {
-                    "scan_interval": "Intervalo de polling (segundos)"
-                }
-            }
-        }
+    "error": {
+      "auth": "Email ou senha incorretos.",
+      "connection": "Não foi possível conectar ao TTLock cloud.",
+      "invalid_code": "O código de verificação não foi aceito. Tente novamente.",
+      "verification_required": "O TTLock requer verificação deste dispositivo. Remova e adicione a integração novamente para completar o fluxo.",
+      "unknown": "Ocorreu um erro desconhecido.",
+      "invalid_mac": "Informe um endereço MAC no formato AA:BB:CC:DD:EE:FF.",
+      "invalid_aes_key": "A chave AES precisa ter 16 bytes em hexadecimal.",
+      "invalid_unlock_key": "A chave de destravamento aceita apenas dígitos.",
+      "invalid_admin_passcode": "A senha de administrador aceita apenas dígitos.",
+      "protocol_mismatch": "A fechadura está anunciando um tipo de protocolo, versão ou cena diferente do que foi informado. Confira os valores nos dados da sua fechadura."
     },
-    "entity": {
-        "binary_sensor": {
-            "presence": {
-                "name": "Disponível"
-            }
-        },
-        "event": {
-            "log": {
-                "name": "Registro",
-                "state_attributes": {
-                    "event_type": {
-                        "state": {
-                            "unlock": "Desbloqueio",
-                            "lock": "Bloqueio",
-                            "unlock_failed": "Falha ao desbloquear",
-                            "password_change": "Alteração de senha",
-                            "other": "Outro"
-                        }
-                    }
-                }
-            }
-        },
-        "lock": {
-            "lock": {
-                "name": "Fechadura"
-            }
-        },
-        "sensor": {
-            "battery": {
-                "name": "Bateria"
-            }
-        }
+    "abort": {
+      "already_configured": "Esta fechadura ou conta já está configurada.",
+      "reauth_successful": "Re-autenticação concluída com sucesso.",
+      "reconfigure_successful": "Reconfiguração concluída com sucesso."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opções do TTLock BLE",
+        "description": "Ajuste polling e outros comportamentos desta entrada.",
+        "data": {
+          "scan_interval": "Intervalo de polling (segundos)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "presence": {
+        "name": "Disponível"
+      }
+    },
+    "event": {
+      "log": {
+        "name": "Registro",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "unlock": "Desbloqueio",
+              "lock": "Bloqueio",
+              "unlock_failed": "Falha ao desbloquear",
+              "password_change": "Alteração de senha",
+              "other": "Outro"
+            }
+          }
+        }
+      }
+    },
+    "lock": {
+      "lock": {
+        "name": "Fechadura"
+      }
+    },
+    "sensor": {
+      "battery": {
+        "name": "Bateria"
+      }
+    }
+  }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,6 @@ max-complexity = 25
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = [
-    "S101", "S105", "S106", "D", "ANN", "ARG001",
+    "S101", "S105", "S106", "D", "ANN", "ARG001", "ARG002",
     "PLC0415", "SLF001", "PLR2004", "PLR0913",
 ]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -49,9 +49,17 @@ def _patch_client(
         yield instance
 
 
-async def _start_user_flow(hass):
+async def _start_menu(hass):
     return await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+
+async def _start_user_flow(hass):
+    """Open the flow and pick the cloud branch, where most tests start."""
+    menu = await _start_menu(hass)
+    return await hass.config_entries.flow.async_configure(
+        menu["flow_id"], user_input={"next_step_id": "cloud"}
     )
 
 
@@ -68,10 +76,16 @@ def _existing_entry(hass, *, username: str = "user@example.com") -> MockConfigEn
 # --- User step -------------------------------------------------------------
 
 
-async def test_step_user_shows_form(hass, enable_custom_integrations) -> None:
+async def test_step_user_offers_both_routes(hass, enable_custom_integrations) -> None:
+    result = await _start_menu(hass)
+    assert result["type"] == FlowResultType.MENU
+    assert result["menu_options"] == ["cloud", "manual"]
+
+
+async def test_step_cloud_shows_form(hass, enable_custom_integrations) -> None:
     result = await _start_user_flow(hass)
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "cloud"
 
 
 async def test_step_user_success_creates_entry(
@@ -196,7 +210,7 @@ async def test_step_user_verification_request_code_communication_error(
             flow["flow_id"], user_input=USER_INPUT
         )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "cloud"
     assert result["errors"] == {"base": "connection"}
 
 
@@ -213,7 +227,7 @@ async def test_step_user_verification_request_code_unknown_error(
             flow["flow_id"], user_input=USER_INPUT
         )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "cloud"
     assert result["errors"] == {"base": "unknown"}
 
 

--- a/tests/test_manual_key.py
+++ b/tests/test_manual_key.py
@@ -1,0 +1,357 @@
+"""Coverage for the manual key route: validation, build, and the config flow steps."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ttlock_ble.const import DOMAIN
+
+MAC = "AA:BB:CC:DD:EE:FF"
+AES_KEY_HEX = "0123456789abcdef0123456789abcdef"
+MANUAL_INPUT = {
+    "lock_mac": MAC,
+    "aes_key": AES_KEY_HEX,
+    "unlock_key": "123456",
+    "admin_passcode": "999999",
+    "lock_name": "Front door",
+    "protocol_type": 5,
+    "protocol_version": 3,
+    "scene": 2,
+    "group_id": 1,
+    "org_id": 1,
+}
+
+
+@pytest.fixture(autouse=True)
+def _lock_out_of_range():
+    """Default every test to a lock nobody has seen, unless it says otherwise.
+
+    Reaching the real bluetooth manager is what the cross-check does in
+    production; here it only couples the validation tests to a stack they
+    are not testing.
+    """
+    with patch(
+        "custom_components.ttlock_ble.manual_key.async_last_service_info",
+        return_value=None,
+    ):
+        yield
+
+
+def _manual_key(hass):
+    from custom_components.ttlock_ble.manual_key import TtlockBleManualKey
+
+    return TtlockBleManualKey(hass)
+
+
+def _advertisement_service_info(scene: int = 2) -> MagicMock:
+    payload = bytes([scene, 0x00, 70, 0, 0, 0, 0]) + bytes.fromhex("ffeeddccbbaa")
+    info = MagicMock()
+    info.manufacturer_data = {0x0305: payload}
+    return info
+
+
+async def _start_manual_flow(hass):
+    menu = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    return await hass.config_entries.flow.async_configure(
+        menu["flow_id"], user_input={"next_step_id": "manual"}
+    )
+
+
+class TestValidation:
+    async def test_accepts_a_well_formed_key(self, hass) -> None:
+        assert _manual_key(hass).async_validate(dict(MANUAL_INPUT)) == {}
+
+    @pytest.mark.parametrize(
+        "mac",
+        ["not-a-mac", "AA:BB:CC:DD:EE", "AABBCCDDEEFF", ""],
+    )
+    async def test_rejects_a_malformed_mac(self, hass, mac) -> None:
+        errors = _manual_key(hass).async_validate({**MANUAL_INPUT, "lock_mac": mac})
+        assert errors["lock_mac"] == "invalid_mac"
+
+    @pytest.mark.parametrize(
+        "aes_key",
+        ["", "0123", "zz23456789abcdef0123456789abcdef", AES_KEY_HEX + "00"],
+    )
+    async def test_rejects_a_malformed_aes_key(self, hass, aes_key) -> None:
+        errors = _manual_key(hass).async_validate({**MANUAL_INPUT, "aes_key": aes_key})
+        assert errors["aes_key"] == "invalid_aes_key"
+
+    async def test_accepts_a_separated_aes_key(self, hass) -> None:
+        separated = ",".join(AES_KEY_HEX[i : i + 2] for i in range(0, 32, 2))
+        assert (
+            _manual_key(hass).async_validate(
+                {**MANUAL_INPUT, "aes_key": separated},
+            )
+            == {}
+        )
+
+    async def test_rejects_a_non_numeric_unlock_key(self, hass) -> None:
+        errors = _manual_key(hass).async_validate(
+            {**MANUAL_INPUT, "unlock_key": "abc"},
+        )
+        assert errors["unlock_key"] == "invalid_unlock_key"
+
+    async def test_rejects_a_non_numeric_admin_passcode(self, hass) -> None:
+        errors = _manual_key(hass).async_validate(
+            {**MANUAL_INPUT, "admin_passcode": "let me in"},
+        )
+        assert errors["admin_passcode"] == "invalid_admin_passcode"
+
+    async def test_admin_passcode_is_optional(self, hass) -> None:
+        assert (
+            _manual_key(hass).async_validate(
+                {**MANUAL_INPUT, "admin_passcode": ""},
+            )
+            == {}
+        )
+
+
+class TestAdvertisementCrossCheck:
+    async def test_matching_advertisement_passes(self, hass) -> None:
+        with patch(
+            "custom_components.ttlock_ble.manual_key.async_last_service_info",
+            return_value=_advertisement_service_info(scene=2),
+        ):
+            assert _manual_key(hass).async_validate(dict(MANUAL_INPUT)) == {}
+
+    async def test_disagreeing_advertisement_is_rejected(self, hass) -> None:
+        """The lock broadcasts its own frame header, so a wrong scene is catchable."""
+        with patch(
+            "custom_components.ttlock_ble.manual_key.async_last_service_info",
+            return_value=_advertisement_service_info(scene=4),
+        ):
+            errors = _manual_key(hass).async_validate(dict(MANUAL_INPUT))
+        assert errors["base"] == "protocol_mismatch"
+
+    async def test_out_of_range_lock_is_not_an_error(self, hass) -> None:
+        with patch(
+            "custom_components.ttlock_ble.manual_key.async_last_service_info",
+            return_value=None,
+        ):
+            assert _manual_key(hass).async_validate(dict(MANUAL_INPUT)) == {}
+
+    async def test_foreign_manufacturer_data_is_not_an_error(self, hass) -> None:
+        info = MagicMock()
+        info.manufacturer_data = {0x004C: b"\x02\x15"}
+        with patch(
+            "custom_components.ttlock_ble.manual_key.async_last_service_info",
+            return_value=info,
+        ):
+            assert _manual_key(hass).async_validate(dict(MANUAL_INPUT)) == {}
+
+
+class TestBuild:
+    async def test_maps_the_form_onto_a_virtual_key(self, hass) -> None:
+        key = _manual_key(hass).build(dict(MANUAL_INPUT))
+        assert key.lockMac == MAC
+        assert key.aesKeyStr == AES_KEY_HEX
+        assert key.unlockKey == "123456"
+        assert key.adminPs == "999999"
+        assert key.lockAlias == "Front door"
+        assert key.lockVersion.protocolType == 5
+        assert key.lockVersion.protocolVersion == 3
+        assert key.lockVersion.scene == 2
+        assert key.lockVersion.groupId == 1
+        assert key.lockVersion.orgId == 1
+
+    async def test_normalises_a_separated_aes_key(self, hass) -> None:
+        """A key the BLE layer could not parse would only fail on connect."""
+        separated = " ".join(AES_KEY_HEX[i : i + 2] for i in range(0, 32, 2))
+        key = _manual_key(hass).build({**MANUAL_INPUT, "aes_key": separated})
+        assert key.aesKeyStr == AES_KEY_HEX
+
+    async def test_stored_key_round_trips_through_the_form(self, hass) -> None:
+        from custom_components.ttlock_ble.manual_key import TtlockBleManualKey
+
+        key = _manual_key(hass).build(dict(MANUAL_INPUT))
+        defaults = TtlockBleManualKey.defaults_from(key.to_dict())
+        rebuilt = _manual_key(hass).build(defaults)
+        assert rebuilt.to_dict() == key.to_dict()
+
+    async def test_names_itself_after_the_mac_when_unnamed(self, hass) -> None:
+        key = _manual_key(hass).build({**MANUAL_INPUT, "lock_name": ""})
+        assert key.lockAlias == f"TTLock {MAC}"
+
+    async def test_lowercase_and_dashed_mac_is_normalised(self, hass) -> None:
+        key = _manual_key(hass).build(
+            {**MANUAL_INPUT, "lock_mac": "aa-bb-cc-dd-ee-ff"},
+        )
+        assert key.lockMac == MAC
+
+    async def test_build_refuses_input_validation_would_reject(self, hass) -> None:
+        with pytest.raises(ValueError, match="async_validate"):
+            _manual_key(hass).build({**MANUAL_INPUT, "aes_key": "nope"})
+
+
+class TestConfigFlow:
+    async def test_manual_step_shows_the_form(
+        self,
+        hass,
+        enable_custom_integrations,
+    ) -> None:
+        result = await _start_manual_flow(hass)
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "manual"
+
+    async def test_manual_step_creates_an_entry_without_credentials(
+        self,
+        hass,
+        enable_custom_integrations,
+    ) -> None:
+        flow = await _start_manual_flow(hass)
+        with patch(
+            "custom_components.ttlock_ble.manual_key.async_last_service_info",
+            return_value=None,
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                flow["flow_id"], user_input=dict(MANUAL_INPUT)
+            )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["title"] == "Front door"
+        assert "username" not in result["data"]
+        assert "password" not in result["data"]
+        assert result["data"]["keys"][0]["lockMac"] == MAC
+        assert result["data"]["keys"][0]["aesKeyStr"] == AES_KEY_HEX
+
+    async def test_manual_step_keeps_the_form_on_bad_input(
+        self,
+        hass,
+        enable_custom_integrations,
+    ) -> None:
+        flow = await _start_manual_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"], user_input={**MANUAL_INPUT, "aes_key": "nope"}
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"]["aes_key"] == "invalid_aes_key"
+
+    async def test_manual_step_is_keyed_by_the_lock_mac(
+        self,
+        hass,
+        enable_custom_integrations,
+    ) -> None:
+        flow = await _start_manual_flow(hass)
+        with patch(
+            "custom_components.ttlock_ble.manual_key.async_last_service_info",
+            return_value=None,
+        ):
+            await hass.config_entries.flow.async_configure(
+                flow["flow_id"], user_input=dict(MANUAL_INPUT)
+            )
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        assert entry.unique_id == MAC.lower()
+
+    async def test_manual_step_rejects_a_second_entry_for_the_same_lock(
+        self,
+        hass,
+        enable_custom_integrations,
+    ) -> None:
+        MockConfigEntry(
+            domain=DOMAIN,
+            data={"keys": []},
+            unique_id=MAC.lower(),
+        ).add_to_hass(hass)
+        flow = await _start_manual_flow(hass)
+        with patch(
+            "custom_components.ttlock_ble.manual_key.async_last_service_info",
+            return_value=None,
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                flow["flow_id"], user_input=dict(MANUAL_INPUT)
+            )
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
+
+class TestReconfigure:
+    async def test_manual_entry_reconfigures_through_the_key_form(
+        self,
+        hass,
+        enable_custom_integrations,
+        mock_ttlock_connection,
+    ) -> None:
+        """An entry with no account must not be sent to the credentials form."""
+        key = _manual_key(hass).build(dict(MANUAL_INPUT))
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"keys": [key.to_dict()]},
+            unique_id=MAC.lower(),
+        )
+        entry.add_to_hass(hass)
+        result = await entry.start_reconfigure_flow(hass)
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "reconfigure_manual"
+
+    async def test_reconfigure_updates_the_stored_key(
+        self,
+        hass,
+        enable_custom_integrations,
+        mock_ttlock_connection,
+    ) -> None:
+        key = _manual_key(hass).build(dict(MANUAL_INPUT))
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"keys": [key.to_dict()]},
+            unique_id=MAC.lower(),
+        )
+        entry.add_to_hass(hass)
+        flow = await entry.start_reconfigure_flow(hass)
+        with patch(
+            "custom_components.ttlock_ble.manual_key.async_last_service_info",
+            return_value=None,
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                flow["flow_id"],
+                user_input={**MANUAL_INPUT, "unlock_key": "654321"},
+            )
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        assert entry.data["keys"][0]["unlockKey"] == "654321"
+
+    async def test_reconfigure_keeps_the_form_on_bad_input(
+        self,
+        hass,
+        enable_custom_integrations,
+        mock_ttlock_connection,
+    ) -> None:
+        key = _manual_key(hass).build(dict(MANUAL_INPUT))
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"keys": [key.to_dict()]},
+            unique_id=MAC.lower(),
+        )
+        entry.add_to_hass(hass)
+        flow = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"],
+            user_input={**MANUAL_INPUT, "unlock_key": "nope"},
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"]["unlock_key"] == "invalid_unlock_key"
+
+
+async def test_manual_step_rejects_a_lock_a_cloud_entry_already_has(
+    hass,
+    enable_custom_integrations,
+) -> None:
+    """A cloud entry is keyed by the account, so the MAC has to be checked too."""
+    key = _manual_key(hass).build(dict(MANUAL_INPUT))
+    MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "user@example.com", "password": "p", "keys": [key.to_dict()]},
+        unique_id="user_example_com",
+    ).add_to_hass(hass)
+    flow = await _start_manual_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], user_input=dict(MANUAL_INPUT)
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/uv.lock
+++ b/uv.lock
@@ -1116,7 +1116,7 @@ wheels = [
 
 [[package]]
 name = "ha-ttlock-ble"
-version = "3.2.2"
+version = "3.2.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Fixes #48

## The problem

A lock initialised by a local BLE bridge is never registered in a TTLock account. Setup could only download keys from the cloud, so those locks had no way in at all — even though their owner already holds everything Bluetooth needs, which is what makes the cloud step redundant in the first place.

## The change

Setup now opens with a menu: sign in to an account, or enter a key directly.

The manual form asks only for what actually reaches the wire — MAC, AES key, unlock key, an optional admin passcode, and the five frame-header integers. Everything else the cloud returns per key is never read: `payload_check_user_time()` is called with no arguments, so the user id and lock-flag position go out zeroed and the dates are the firmware's "permanent key" literals, whatever validity window the cloud reported. Asking for those fields would only invite people to hunt down values that make no difference.

Three details are easy to get wrong, and each would fail late rather than loudly:

- **The unlock key and admin passcode are stored verbatim.** The cloud delivers them obfuscated and the cloud path decodes them; a locally obtained one is already plain, and decoding it again would corrupt it.
- **The AES key is normalised to continuous hex on save.** The form accepts more separators than the library parses, so a space-separated paste would be accepted and then fail at the first connection, long after the entry looked healthy.
- **The frame header is cross-checked against the lock.** When the lock is in range, its advertised protocol type, version and scene are compared with what was entered, turning a typo into a form error instead of a lock that never answers. `group_id` and `org_id` are not advertised and cannot be checked this way.

A lock already held by another entry is now rejected outright. A cloud entry's unique id is the account, not the MAC, so the same lock could previously be added twice; the second entry would then collide on entity unique ids and come up with no entities at all.

Reconfigure follows whichever route created the entry — with no account to re-prompt for, a manual entry re-opens the key form pre-filled, so a mistyped key is fixable without deleting the entry.

`username`/`password` become optional on the stored entry data accordingly.

## Verification

213 tests, 99.81% coverage, and the two assertions that need real hardware were driven against a live install and a real lock:

- entering a deliberately wrong `scene` is rejected as `protocol_mismatch`, from what the lock actually broadcasts;
- entering the correct values for a lock an existing cloud entry already holds aborts as `already_configured`.

## Notes

The existing credentials step is now reached as `cloud` rather than `user`, since `user` is the menu. Existing entries are unaffected — flow step ids are not persisted — and `reauth_confirm` is unchanged.