### PR TITLE
chore: move CI to the shared workflows repository

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,9 +13,11 @@ concurrency:
   group: auto-assign
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   auto-assign:
     permissions:
       issues: write
       pull-requests: write
-    uses: roquerodrigo/.github/.github/workflows/auto-assign.yml@main
+    uses: roquerodrigo/workflows/.github/workflows/auto-assign.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,24 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
 jobs:
   lint:
-    uses: roquerodrigo/.github/.github/workflows/ha-lint.yml@v2
+    uses: roquerodrigo/workflows/.github/workflows/python-lint.yml@main
 
   tests:
     needs: lint
-    uses: roquerodrigo/.github/.github/workflows/ha-tests.yml@v2
+    uses: roquerodrigo/workflows/.github/workflows/python-test.yml@main
 
   validate:
     needs: lint
-    uses: roquerodrigo/.github/.github/workflows/ha-validate.yml@v2
+    uses: roquerodrigo/workflows/.github/workflows/home-assistant-validate.yml@main
 
   update-pr-branch:
     if: github.event_name == 'pull_request'
@@ -27,4 +31,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: roquerodrigo/.github/.github/workflows/ha-update-pr-branch.yml@v2
+    uses: roquerodrigo/workflows/.github/workflows/update-pr-branch.yml@main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,8 +8,7 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   codeql:
@@ -17,4 +16,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: roquerodrigo/.github/.github/workflows/ha-codeql.yml@v2
+    uses: roquerodrigo/workflows/.github/workflows/codeql.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,25 @@
 name: Release
 
+# Gated on a successful CI run rather than on the push itself. The
+# `workflow_run.event == 'push'` half of the condition is what stops a pull
+# request with green CI from cutting a release.
+
 on:
   workflow_run:
     workflows: [CI]
     types: [completed]
     branches: [main]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   release:
-    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: write
       pull-requests: write
-    uses: roquerodrigo/.github/.github/workflows/ha-release.yml@v2
-    secrets: inherit
+    uses: roquerodrigo/workflows/.github/workflows/release-please.yml@main
+    secrets:
+      release-token: ${{ secrets.RELEASE_PLEASE_PAT }}


### PR DESCRIPTION
Points the pipelines at the reusable workflows in `roquerodrigo/workflows`, which replaces `roquerodrigo/.github`.

What changes for this repository:

- CI, CodeQL and release wire up ecosystem-oriented reusable workflows instead of consumer-specific ones.
- Every job declares a timeout, and pull request runs are cancelled when superseded.
- Actions are pinned by commit digest, and dependency setup is cached.