### PR TITLE
chore: release on every conventional commit type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       time: "09:00"
       timezone: "America/Sao_Paulo"
 
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -20,6 +24,10 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+    commit-message:
+      prefix: "deps"
+      include: "scope"
 
   - package-ecosystem: "uv"
     directory: "/"
@@ -37,3 +45,7 @@ updates:
     ignore:
       # Dependabot should not update Home Assistant as that should match the homeassistant key in hacs.json
       - dependency-name: "homeassistant"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,12 +34,20 @@
           "section": "Performance Improvements"
         },
         {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
           "type": "deps",
           "section": "Dependencies"
         },
         {
-          "type": "revert",
-          "section": "Reverts"
+          "type": "deps-dev",
+          "section": "Development Dependencies"
         },
         {
           "type": "docs",
@@ -47,33 +55,23 @@
         },
         {
           "type": "build",
-          "section": "Build System",
-          "hidden": true
+          "section": "Build System"
         },
         {
           "type": "ci",
-          "section": "Continuous Integration",
-          "hidden": true
-        },
-        {
-          "type": "chore",
-          "section": "Miscellaneous Chores",
-          "hidden": true
-        },
-        {
-          "type": "refactor",
-          "section": "Code Refactoring",
-          "hidden": true
-        },
-        {
-          "type": "style",
-          "section": "Styles",
-          "hidden": true
+          "section": "Continuous Integration"
         },
         {
           "type": "test",
-          "section": "Tests",
-          "hidden": true
+          "section": "Tests"
+        },
+        {
+          "type": "style",
+          "section": "Styles"
+        },
+        {
+          "type": "chore",
+          "section": "Miscellaneous Chores"
         }
       ]
     }


### PR DESCRIPTION
Aligns the release-please and Dependabot configuration across repositories.

- Every conventional commit type is now user facing, so any of them cuts a release. A hidden type does not merely stay out of the changelog: release-please skips the release entirely when no user facing commit exists.
- `deps-dev` is declared explicitly instead of releasing by virtue of being an unlisted type.
- Dependabot labels its commits `deps` and `deps-dev`, so dependency updates land under Dependencies rather than Miscellaneous Chores.