### PR TITLE
feat(lock): report the locking and unlocking transitional states

### DIFF
--- a/custom_components/ttlock_ble/lock.py
+++ b/custom_components/ttlock_ble/lock.py
@@ -49,7 +49,16 @@ class TtlockBleLock(TtlockBleEntity, LockEntity):
     """
     Smart lock backed by a persistent `TtlockBleConnection`.
 
-    State is reported via `_attr_is_locked`. It is updated:
+    While a command is in flight the entity reports the transitional
+    states HA defines for the platform — `locking` and `unlocking` —
+    covering the BLE session setup plus the round trip to the lock,
+    which is seconds rather than milliseconds. `jammed`, `open` and
+    `opening` are deliberately never reported: the firmware exposes no
+    jam signal (only a bolt position and a success/failure byte) and
+    has no latch command distinct from unlocking, so any value there
+    would be a guess.
+
+    Settled state is reported via `_attr_is_locked`. It is updated:
     - On every coordinator refresh that returned a known lock state —
       which includes the state decoded from the lock's advertisements,
       the only channel that reports an auto-lock.
@@ -79,6 +88,8 @@ class TtlockBleLock(TtlockBleEntity, LockEntity):
         super().__init__(coordinator, key)
         self._connection = connection
         self._attr_is_locked = None
+        self._attr_is_locking = False
+        self._attr_is_unlocking = False
         self._settle_until: float = 0.0
         self._sync_from_coordinator()
 
@@ -180,20 +191,35 @@ class TtlockBleLock(TtlockBleEntity, LockEntity):
 
     async def _async_run_command(self, action: str) -> None:
         """Dispatch the BLE command, optimistically update state, refresh."""
+        self._set_in_flight(action)
         try:
             if action == "lock":
                 await self._connection.async_lock()
             else:
                 await self._connection.async_unlock()
         except TTLockError as exc:
+            self._clear_in_flight()
+            self.async_write_ha_state()
             LOGGER.warning("BLE %s failed for %s: %s", action, self._key.lockMac, exc)
             msg = f"Failed to {action} {self._key.lockMac}: {exc}"
             raise HomeAssistantError(msg) from exc
+        self._clear_in_flight()
         self._attr_is_locked = action == "lock"
         self._settle_until = time.monotonic() + COMMAND_SETTLE_SECONDS
         self.async_write_ha_state()
         self.hass.async_create_task(self._async_fetch_log_after_command())
         await self.coordinator.async_request_refresh()
+
+    def _set_in_flight(self, action: str) -> None:
+        """Publish the transitional state for a command that just started."""
+        self._attr_is_locking = action == "lock"
+        self._attr_is_unlocking = action != "lock"
+        self.async_write_ha_state()
+
+    def _clear_in_flight(self) -> None:
+        """Drop the transitional state without publishing it on its own."""
+        self._attr_is_locking = False
+        self._attr_is_unlocking = False
 
     async def _async_fetch_log_after_command(self) -> None:
         """Fetch operation log shortly after a command to capture the new record."""

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -319,6 +319,119 @@ async def test_lock_event_with_decoded_state_respects_settle_window(
     assert hass.states.get(state.entity_id).state == "unlocked"
 
 
+async def test_unlock_reports_unlocking_while_in_flight(
+    hass,
+    setup_integration,
+    mock_ttlock_connection,
+) -> None:
+    """The entity sits on `unlocking` for as long as the BLE command runs."""
+    import asyncio
+
+    from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+    from homeassistant.components.lock import SERVICE_UNLOCK
+
+    started = asyncio.Event()
+    released = asyncio.Event()
+
+    async def blocking_unlock() -> None:
+        started.set()
+        await released.wait()
+
+    mock_ttlock_connection.async_unlock = AsyncMock(side_effect=blocking_unlock)
+    state = hass.states.async_all("lock")[0]
+    assert state.state == "locked"
+    # The post-command refresh finds the lock out of range.
+    mock_ttlock_connection.async_query_state = AsyncMock(return_value=None)
+    call = hass.async_create_task(
+        hass.services.async_call(
+            LOCK_DOMAIN,
+            SERVICE_UNLOCK,
+            {"entity_id": state.entity_id},
+            blocking=True,
+        )
+    )
+    async with asyncio.timeout(5):
+        await started.wait()
+    assert hass.states.get(state.entity_id).state == "unlocking"
+    released.set()
+    await call
+    await hass.async_block_till_done()
+    assert hass.states.get(state.entity_id).state == "unlocked"
+
+
+async def test_lock_reports_locking_while_in_flight(
+    hass,
+    setup_integration,
+    mock_ttlock_connection,
+) -> None:
+    """The entity sits on `locking` for as long as the BLE command runs."""
+    import asyncio
+
+    from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+    from homeassistant.components.lock import SERVICE_LOCK
+
+    started = asyncio.Event()
+    released = asyncio.Event()
+
+    async def blocking_lock() -> None:
+        started.set()
+        await released.wait()
+
+    mock_ttlock_connection.async_lock = AsyncMock(side_effect=blocking_lock)
+    # The post-command refresh finds the lock out of range.
+    mock_ttlock_connection.async_query_state = AsyncMock(return_value=None)
+    state = hass.states.async_all("lock")[0]
+    call = hass.async_create_task(
+        hass.services.async_call(
+            LOCK_DOMAIN,
+            SERVICE_LOCK,
+            {"entity_id": state.entity_id},
+            blocking=True,
+        )
+    )
+    async with asyncio.timeout(5):
+        await started.wait()
+    assert hass.states.get(state.entity_id).state == "locking"
+    released.set()
+    await call
+    await hass.async_block_till_done()
+    assert hass.states.get(state.entity_id).state == "locked"
+
+
+async def test_failed_command_clears_transitional_state(
+    hass,
+    setup_integration,
+    mock_ttlock_connection,
+) -> None:
+    """A rejected command drops `unlocking` instead of stranding the UI on it."""
+    from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+    from homeassistant.components.lock import SERVICE_UNLOCK
+
+    mock_ttlock_connection.async_unlock = AsyncMock(side_effect=TTLockError("offline"))
+    state = hass.states.async_all("lock")[0]
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            LOCK_DOMAIN,
+            SERVICE_UNLOCK,
+            {"entity_id": state.entity_id},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+    assert hass.states.get(state.entity_id).state == "locked"
+
+
+async def test_lock_never_reports_jammed_or_open(hass, setup_integration) -> None:
+    """The firmware has no jam or latch signal, so those stay unreported."""
+    from homeassistant.components.lock import DATA_COMPONENT
+
+    state = hass.states.async_all("lock")[0]
+    entity = hass.data[DATA_COMPONENT].get_entity(state.entity_id)
+    assert entity is not None
+    assert entity.is_jammed is None
+    assert entity.is_open is None
+    assert entity.is_opening is None
+
+
 async def test_lock_has_unique_id(hass, setup_integration, sample_virtual_key) -> None:
     from homeassistant.helpers import entity_registry as er
 


### PR DESCRIPTION
## What changes

The lock entity previously jumped straight from `locked` to `unlocked` (and back) even though a BLE command takes seconds to complete: the session has to be established and the lock has to answer. During that window the UI kept showing the old state, so a press looked like it had done nothing.

The entity now publishes the [`locking` and `unlocking` states](https://www.home-assistant.io/integrations/lock/) the lock platform defines for exactly this window, and clears them both when the command completes and when it is rejected — a failed command falls back to the last known state instead of stranding the entity on a transitional one.

`jammed`, `open` and `opening` remain unreported. The firmware exposes no jam signal (only a bolt position and a success/failure byte) and has no latch command distinct from unlocking, so any value there would be a guess.

## Verification

Lint, typing and the test suite pass. Three tests cover the new behaviour: the transitional state while a command is in flight, for both directions, and its clearing when a command is rejected.

Exercised against a physical lock:

| | `locking` | resolved |
|---|---|---|
| command rejected (BLE timeout) | 19:22:39 | `locked` 19:22:45 |
| command accepted | 19:23:05 | `locked` 19:23:47 |