### PR TITLE
deps(ttlock-ble): bump to 0.1.10

### DIFF
--- a/custom_components/ttlock_ble/manifest.json
+++ b/custom_components/ttlock_ble/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/roquerodrigo/ha-ttlock-ble/issues",
   "requirements": [
-    "ttlock-ble==0.1.8"
+    "ttlock-ble==0.1.10"
   ],
   "version": "3.3.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dev = [
     "pytest-cov==7.1.0",
     "pytest-homeassistant-custom-component==0.13.332",
     "serialx==1.8.2",
-    "ttlock-ble==0.1.8",
+    "ttlock-ble==0.1.10",
 ]
 lint = [
     "ruff==0.16.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1158,7 +1158,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.332" },
     { name = "serialx", specifier = "==1.8.2" },
-    { name = "ttlock-ble", specifier = "==0.1.8" },
+    { name = "ttlock-ble", specifier = "==0.1.10" },
 ]
 lint = [
     { name = "mypy", specifier = "==2.3.0" },
@@ -2795,7 +2795,7 @@ wheels = [
 
 [[package]]
 name = "ttlock-ble"
-version = "0.1.8"
+version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
@@ -2805,9 +2805,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/38/79d0d62b1df9f554353fd7a418f7171b72a925cd6ad2c06cbaa3f54b95ec/ttlock_ble-0.1.8.tar.gz", hash = "sha256:a1d4b43812710a9627d3132c05cdf2dd2319b4a4d4bfb816b100ccf5d620724b", size = 128980, upload-time = "2026-07-29T18:04:11.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/be/011c6ef64287e31e4ca251d37423344c0cefadd80536edbc49cbf573b4ac/ttlock_ble-0.1.10.tar.gz", hash = "sha256:2c7eb2be7cdf32628a7441ffb3daf1165a9377c4f62cf6eb57ded69bf0bd7c07", size = 131731, upload-time = "2026-08-05T00:58:45.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/a8/88a6fb363979249e65744a0f123fc7ee0f5e340721f9775c0847b90968d8/ttlock_ble-0.1.8-py3-none-any.whl", hash = "sha256:9f6b8441583e9af70f78c75fd8acc80ed8bac27fa735696947ba8108a2a13c86", size = 45496, upload-time = "2026-07-29T18:04:10.244Z" },
+    { url = "https://files.pythonhosted.org/packages/73/68/66159da3a7ebbcfd119c834eb14e2ab1caacaba39c25c2a047d9d74ec688/ttlock_ble-0.1.10-py3-none-any.whl", hash = "sha256:e37f007361e1378366a18a07453108b17fb69c0d0c8cacb107389d083a215d85", size = 46266, upload-time = "2026-08-05T00:58:44.148Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changes

Moves the `ttlock-ble` pin from 0.1.8 to 0.1.10, in both places that can drift: `manifest.json` (what HACS installs for users) and `pyproject.toml` (what CI runs against). `uv.lock` regenerated.

**0.1.9 is skipped deliberately.** It added opcode matching in the SDK's `_exchange` so a push event could not be mistaken for a command reply, but compared the frame-level command byte — which is `CMD_RESPONSE` (0x54) on every lock-to-phone frame, whatever it answers. The echoed opcode lives in the decrypted payload, so the comparison matched nothing: every genuine reply was routed away as a push and every command timed out after 6 seconds. 0.1.10 compares the right byte and should be used instead.

No public API changed, so nothing in the integration needed adjusting.

## Verification

Lint, typing and the suite pass against 0.1.10.

Verified against a physical lock with the released package installed from PyPI (not a local build): all four entities load and a lock command completes, `locking` 22:05:57 → `locked` 22:06:08, with no warning logged.