### PR TITLE
chore: repair scripts/setup and align local tooling with the uv workflow

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ludeeus/ttlock_ble",
+    "name": "roquerodrigo/ha-ttlock-ble",
     "image": "mcr.microsoft.com/devcontainers/base:debian",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
@@ -40,6 +40,7 @@
         "ghcr.io/devcontainers/features/python:1": {
             "version": "3.14"
         },
+        "ghcr.io/va-h/devcontainers-features/uv:1": {},
         "ghcr.io/devcontainers-extra/features/apt-packages:1": {
             "packages": "ffmpeg,libturbojpeg0,libpcap-dev"
         }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,28 @@
 # Run with: pre-commit install (after scripts/setup)
-# CI mirrors these checks via .github/workflows/lint.yml
+# CI mirrors these checks via .github/workflows/ci.yml
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+  - repo: local
     hooks:
-      - id: ruff-check
-        args: [--fix]
       - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        types_or: [python, pyi]
+        require_serial: true
+
+      - id: ruff-check
+        name: ruff check
+        entry: uv run ruff check --fix
+        language: system
+        types_or: [python, pyi]
+        require_serial: true
+
+      - id: mypy
+        name: mypy
+        entry: uv run mypy custom_components/ttlock_ble
+        language: system
+        pass_filenames: false
+        types: [python]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/scripts/setup
+++ b/scripts/setup
@@ -4,10 +4,4 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-# Auto-use ./.venv if present so callers don't need to `source activate`.
-if [ -d "${PWD}/.venv" ]; then
-    export PATH="${PWD}/.venv/bin:${PATH}"
-    export VIRTUAL_ENV="${PWD}/.venv"
-fi
-
-python3 -m pip install --requirement requirements.txt
+uv sync --group dev --group lint


### PR DESCRIPTION
## Summary

Local developer tooling had drifted from the uv-based workflow the repo actually uses:

- `scripts/setup` ran `pip install --requirement requirements.txt`, a file that no longer exists — the script (and the devcontainer, which runs it as `postCreateCommand`) has been broken since the migration to uv.
- The pre-commit ruff hook pinned a mirror rev behind the ruff version in `pyproject.toml`, so a local commit could format differently from CI, and no mypy hook existed.
- The devcontainer still carried the upstream template's name.

## Changes

- `scripts/setup` now runs `uv sync --group dev --group lint`.
- `.pre-commit-config.yaml` switches to local `uv run` hooks (ruff format, ruff check --fix, mypy) so the hook always uses the exact versions pinned in `pyproject.toml`; the file-hygiene hooks stay. The stale comment pointing at a nonexistent `lint.yml` workflow now points at `ci.yml`.
- `.devcontainer.json` installs uv via a devcontainer feature and is renamed to `roquerodrigo/ha-ttlock-ble`.

## Verification

Full lint + mypy + test suite green (262 passed, coverage 100%).