### PR TITLE
ci: run checks on pull requests targeting any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   schedule:
     - cron: "0 0 * * 0"
 


### PR DESCRIPTION
Stacked pull requests target the branch below them rather than `main`. With the base-branch filter on the `pull_request` trigger, their checks never ran and every layer above the bottom one reported no status at all.

Dropping the filter keeps the same checks on every pull request, whatever its base.