### PR TITLE
fix: keep the lock state when the operation-log read fails

### DIFF
--- a/custom_components/ttlock_ble/connection.py
+++ b/custom_components/ttlock_ble/connection.py
@@ -177,7 +177,14 @@ class TtlockBleConnection:
                 entries = await client.get_operation_log(
                     max_entries=MAX_LOG_ENTRIES_PER_FETCH,
                 )
-            except TTLockError as exc:
+            except Exception as exc:  # noqa: BLE001
+                # `TTLockError` alone is not enough: the SDK's log path
+                # reaches `aes_decrypt` unwrapped and raises `ValueError`
+                # on a garbled frame, and `bleak` raises `BleakError` when
+                # the link drops mid-fetch. Letting those out would fail
+                # the whole poll and discard the state read that already
+                # succeeded, leaving the lock entity reporting a stale
+                # value instead of merely losing its history.
                 LOGGER.warning(
                     "get_operation_log failed for %s: %s",
                     self._key.lockMac,

--- a/custom_components/ttlock_ble/coordinator.py
+++ b/custom_components/ttlock_ble/coordinator.py
@@ -122,7 +122,19 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
         if result is None:
             return {"locked": None, "battery_level": None}
         raw_state, battery = result
-        await connection.async_get_operation_log()
+        try:
+            await connection.async_get_operation_log()
+        except Exception:  # noqa: BLE001
+            # The log feeds the event entity only. Failing the poll here
+            # would throw away the state and battery already read, and the
+            # entity would keep whatever HA last wrote optimistically —
+            # a confidently wrong value that silently disables any
+            # state-based automation built on it.
+            LOGGER.debug(
+                "Operation log read failed for %s; keeping the state read",
+                connection.key.lockMac,
+                exc_info=True,
+            )
         return {
             "locked": _parse_lock_state(raw_state),
             "battery_level": battery,

--- a/custom_components/ttlock_ble/manifest.json
+++ b/custom_components/ttlock_ble/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/roquerodrigo/ha-ttlock-ble/issues",
   "requirements": [
-    "ttlock-ble==0.1.10"
+    "ttlock-ble==0.1.11"
   ],
   "version": "3.4.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
     "pytest-cov==7.1.0",
     "pytest-homeassistant-custom-component==0.13.354",
     "serialx==1.8.2",
-    "ttlock-ble==0.1.10",
+    "ttlock-ble==0.1.11",
 ]
 lint = [
     "ruff==0.16.1",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -446,6 +446,28 @@ async def test_get_operation_log_returns_empty_on_ttlock_error(
     assert await conn.async_get_operation_log() == []
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        ValueError(
+            "The length of the provided data is not a multiple of the block length"
+        ),
+        RuntimeError("lock rejected checkUserTime"),
+    ],
+)
+async def test_get_operation_log_returns_empty_on_unwrapped_error(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+    error: Exception,
+) -> None:
+    """The SDK's log path raises outside TTLockError; the fetch still returns []."""
+    mock_ttlock_client.get_operation_log = AsyncMock(side_effect=error)
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_get_operation_log() == []
+
+
 async def test_get_operation_log_dispatches_only_new_records(
     hass,
     sample_virtual_key,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -39,6 +39,15 @@ def _coordinator(hass, connections):
     )
 
 
+async def test_poll_keeps_state_when_log_read_fails(hass) -> None:
+    """The operation log only feeds the event entity; it must not void the state."""
+    conn = _mock_connection(query_return=(0, 80))
+    conn.async_get_operation_log = AsyncMock(side_effect=ValueError("garbled frame"))
+    coordinator = _coordinator(hass, {"AA:BB:CC:DD:EE:FF": conn})
+    data = await coordinator._async_update_data()
+    assert data["AA:BB:CC:DD:EE:FF"] == {"locked": True, "battery_level": 80}
+
+
 async def test_coordinator_exposes_connections(hass) -> None:
     connections = {"AA:BB:CC:DD:EE:FF": _mock_connection()}
     coordinator = _coordinator(hass, connections)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,38 @@
+"""The manifest pin and the tested pin must name the same SDK release."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SDK = "ttlock-ble"
+
+
+def _pinned(requirements: list[str], package: str) -> str | None:
+    """Return the version `package` is pinned to within `requirements`."""
+    for requirement in requirements:
+        name, separator, version = requirement.partition("==")
+        if separator and name.strip() == package:
+            return version.strip()
+    return None
+
+
+def test_manifest_and_dev_group_pin_the_same_sdk_version() -> None:
+    """Home Assistant installs the manifest pin; the suite runs the dev-group one.
+
+    When they drift, every test passes against a release the running
+    integration never sees.
+    """
+    manifest = json.loads(
+        (_ROOT / "custom_components" / "ttlock_ble" / "manifest.json").read_text(),
+    )
+    pyproject = tomllib.loads((_ROOT / "pyproject.toml").read_text())
+
+    manifest_pin = _pinned(manifest["requirements"], _SDK)
+    dev_pin = _pinned(pyproject["dependency-groups"]["dev"], _SDK)
+
+    assert manifest_pin is not None, f"{_SDK} is not pinned in manifest.json"
+    assert dev_pin is not None, f"{_SDK} is not pinned in the dev dependency group"
+    assert manifest_pin == dev_pin

--- a/uv.lock
+++ b/uv.lock
@@ -255,15 +255,6 @@ wheels = [
 ]
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -756,18 +747,6 @@ wheels = [
 ]
 
 [[package]]
-name = "click"
-version = "8.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1150,7 +1129,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.354" },
     { name = "serialx", specifier = "==1.8.2" },
-    { name = "ttlock-ble", specifier = "==0.1.10" },
+    { name = "ttlock-ble", specifier = "==0.1.11" },
 ]
 lint = [
     { name = "mypy", specifier = "==2.3.0" },
@@ -1482,18 +1461,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown-it-py"
-version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
-]
-
-[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1533,15 +1500,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ee/61/bdbd92fd7684f31fe18982f5a3b9a6ab672ae81a7f52b8aceecb56143430/mashumaro-3.21.tar.gz", hash = "sha256:9bc53b0c7dbed0be80e3ccc3efe1d621ce146b4b7a673ec41ba001a417f2c4b4", size = 195595, upload-time = "2026-05-07T16:32:35.809Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2e/d6a3410c11ac71e6031d7779d20700b43866e8166d56be86cf8bfcbb15de/mashumaro-3.21-py3-none-any.whl", hash = "sha256:b8e11e259a77d1c6e277c17909381448750956acee1eb79014b06704a10053d6", size = 95250, upload-time = "2026-05-07T16:32:34.341Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -2409,15 +2367,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
 name = "python-slugify"
 version = "8.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2554,19 +2503,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "15.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2644,15 +2580,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/1d/8dfbd66cdf4129d991574c4ebcd502636b178e408a41cdf8ebc04353cab5/serialx-1.8.2-cp310-abi3-win_amd64.whl", hash = "sha256:3e098c502639c7b220c419634101f28b9878a82fcee0cf06e074abb3e97f2c3e", size = 189886, upload-time = "2026-06-12T16:06:52.792Z" },
     { url = "https://files.pythonhosted.org/packages/85/b9/138584b89a109f4e4ce82176380b44a748808033d55c9cbb1b39de0f52eb/serialx-1.8.2-cp310-abi3-win_arm64.whl", hash = "sha256:36f82e21c9b0215beae4c983d221071a44ecdcf2f7a98c659af596ff7adbaa65", size = 186459, upload-time = "2026-06-12T16:06:54.283Z" },
     { url = "https://files.pythonhosted.org/packages/f0/90/9cd83042a221756e41ed8c018344e8833788c16e9bac144dab3292f9fa3c/serialx-1.8.2-py3-none-any.whl", hash = "sha256:6e6cffc1caec242fb06d8e16dd7880c8ba53c366ee2c43045fc38e8935ac8a6d", size = 66674, upload-time = "2026-06-12T16:06:55.724Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -2770,34 +2697,17 @@ wheels = [
 
 [[package]]
 name = "ttlock-ble"
-version = "0.1.10"
+version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
     { name = "bleak-retry-connector" },
     { name = "cryptography" },
     { name = "httpx" },
-    { name = "python-dotenv" },
-    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/be/011c6ef64287e31e4ca251d37423344c0cefadd80536edbc49cbf573b4ac/ttlock_ble-0.1.10.tar.gz", hash = "sha256:2c7eb2be7cdf32628a7441ffb3daf1165a9377c4f62cf6eb57ded69bf0bd7c07", size = 131731, upload-time = "2026-08-05T00:58:45.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/df/0fadbaf14c39a799e85a950c7c760e0d6db1754c7984ddf2ed7b3c11c180/ttlock_ble-0.1.11.tar.gz", hash = "sha256:21af2da1d62fec8cc6e52c85b9e9ad1d41be5aca544a37713c5105dd5422bc68", size = 44280, upload-time = "2026-08-07T18:46:36.407Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/68/66159da3a7ebbcfd119c834eb14e2ab1caacaba39c25c2a047d9d74ec688/ttlock_ble-0.1.10-py3-none-any.whl", hash = "sha256:e37f007361e1378366a18a07453108b17fb69c0d0c8cacb107389d083a215d85", size = 46266, upload-time = "2026-08-05T00:58:44.148Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.25.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/4c/376161dfafbf51200c6659064096654fdc8af8319ce30268e4934ba100a1/ttlock_ble-0.1.11-py3-none-any.whl", hash = "sha256:9d25a0a00f6afbcf3693d5cea781a74f75aa251e29349c3da2d7d6bf9e02e83e", size = 56254, upload-time = "2026-08-07T18:46:35.488Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The operation log feeds the event entity only, but a failure while reading it aborted the whole poll and discarded the state and battery that same poll had already read. The coordinator then published a null state, so the entity kept whatever Home Assistant last wrote optimistically.

With the default one-hour scan interval that is the only channel refreshing the entity from the device, so anything done outside Home Assistant stayed invisible indefinitely. A confidently wrong `locked` is worse than an unavailable entity: a state condition reads the stale value and the automation silently does nothing.

Two layers were involved:

- `async_get_operation_log` documents that it returns an empty list on failure, but only caught `TTLockError`. The SDK's log path reaches `aes_decrypt` unwrapped and raises `ValueError` on a garbled frame, which is the reported failure.
- The coordinator had no guard of its own, so the invariant depended on that discipline holding. It now holds regardless of what the connection lets through.

Also pins `ttlock-ble` to 0.1.11, which fixes the framing bug that made this reproduce permanently on affected locks, and adds a test asserting the manifest pin and the tested pin name the same release.

Fixes #74