### PR TITLE
feat(hacs): ship the install zip with every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,3 +23,13 @@ jobs:
     uses: roquerodrigo/workflows/.github/workflows/release-please.yml@main
     secrets:
       release-token: ${{ secrets.RELEASE_PLEASE_PAT }}
+
+  publish:
+    needs: release
+    if: needs.release.outputs.release-created == 'true'
+    permissions:
+      contents: write
+    uses: roquerodrigo/workflows/.github/workflows/publish-hacs-zip.yml@main
+    with:
+      domain: ttlock_ble
+      ref: ${{ needs.release.outputs.tag-name }}

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,7 @@
 {
     "name": "TTLock BLE",
+    "zip_release": true,
+    "filename": "ttlock_ble.zip",
     "homeassistant": "2026.5.1",
     "hacs": "2.0.5"
 }


### PR DESCRIPTION
Declares `zip_release` in `hacs.json` and composes `publish-hacs-zip.yml` after the release job, so every release carries an install archive of `custom_components/<domain>/`.

Until now HACS installed this integration one file at a time through the GitHub API, and those reads are counted nowhere. With the asset in place the release's `download_count` becomes the install counter — the only usage figure available per repository, since the analytics Home Assistant publishes are keyed by integration domain and cannot separate one project from another that shares it.

The archive takes effect from the next release; existing releases are unaffected.