### PR TITLE
fix(advertisement): keep the known state when the lock is dormant

### DIFF
--- a/custom_components/ttlock_ble/advertisement.py
+++ b/custom_components/ttlock_ble/advertisement.py
@@ -43,6 +43,11 @@ class TtlockBleAdvertisementTracker:
     An advertisement that decodes into a state also postpones the next
     poll: `async_set_updated_data` reschedules the coordinator, so a lock
     that keeps advertising is never connected to just to be read.
+
+    A dormant lock advertises without a usable bolt position, so those
+    frames only carry battery. While no state is known at all they still
+    fall through to the bootstrap poll below, same as a payload that does
+    not decode.
     """
 
     def __init__(
@@ -78,7 +83,8 @@ class TtlockBleAdvertisementTracker:
         advertisement = self._decode(mac, service_info)
         if advertisement is not None:
             self._coordinator.async_apply_advertisement(mac, advertisement)
-            return
+            if advertisement.lock_state is not None:
+                return
         if self._coordinator.async_has_state(mac):
             return
         LOGGER.debug(

--- a/custom_components/ttlock_ble/coordinator.py
+++ b/custom_components/ttlock_ble/coordinator.py
@@ -84,15 +84,34 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
 
         Also reschedules the next poll: a lock that keeps advertising
         reports itself for free, so there is nothing to connect for.
+
+        A dormant advertisement carries no bolt position — the firmware
+        clears that bit along with the radio, so the payload is
+        indistinguishable from a locked one — and only its battery is
+        adopted, leaving whatever state was last known in place. The
+        poll is still rescheduled: a dormant lock refuses connections,
+        so there is nothing a round trip could add.
         """
+        state_name = (
+            "UNKNOWN"
+            if advertisement.lock_state is None
+            else advertisement.lock_state.name
+        )
         LOGGER.debug(
-            "Advertised state for %s (lock_state=%s battery=%d)",
+            "Advertised state for %s (lock_state=%s battery=%d dormant=%s)",
             mac,
-            advertisement.lock_state.name,
+            state_name,
             advertisement.battery,
+            advertisement.is_dormant,
+        )
+        previous = (self.data or {}).get(mac) or {}
+        locked = (
+            previous.get("locked")
+            if advertisement.lock_state is None
+            else advertisement.lock_state is LockState.LOCKED
         )
         snapshot: TtlockBleLockState = {
-            "locked": advertisement.lock_state is LockState.LOCKED,
+            "locked": locked,
             "battery_level": advertisement.battery,
         }
         self.async_set_updated_data({**(self.data or {}), mac: snapshot})

--- a/custom_components/ttlock_ble/data/diagnostics_advertisement.py
+++ b/custom_components/ttlock_ble/data/diagnostics_advertisement.py
@@ -14,9 +14,13 @@ class TtlockBleDiagnosticsAdvertisement(TypedDict):
     diagnosable: `decoded` is `None` whenever the payload does not match
     the layout this integration knows, and the raw bytes are then the
     only way to tell which layout the firmware actually uses.
+
+    Inside `decoded`, `lock_state` is `None` when the lock was dormant:
+    the frame decodes, but its bolt bit is cleared by the radio going
+    down rather than by the bolt moving.
     """
 
     source: str
     rssi: int
     manufacturer_data: dict[str, str]
-    decoded: dict[str, str | int | bool] | None
+    decoded: dict[str, str | int | bool | None] | None

--- a/custom_components/ttlock_ble/diagnostics.py
+++ b/custom_components/ttlock_ble/diagnostics.py
@@ -94,7 +94,7 @@ def _summarize_advertisement(
     service_info = async_last_service_info(hass, mac, connectable=False)
     if service_info is None:
         return None
-    decoded: dict[str, str | int | bool] | None = None
+    decoded: dict[str, str | int | bool | None] | None = None
     for company_id, payload in service_info.manufacturer_data.items():
         advertisement = LockAdvertisement.from_manufacturer_data(company_id, payload)
         if advertisement is not None:
@@ -102,9 +102,14 @@ def _summarize_advertisement(
                 "protocol_type": advertisement.protocol_type,
                 "protocol_version": advertisement.protocol_version,
                 "scene": advertisement.scene,
-                "lock_state": advertisement.lock_state.name,
+                "lock_state": (
+                    None
+                    if advertisement.lock_state is None
+                    else advertisement.lock_state.name
+                ),
                 "has_new_records": advertisement.has_new_records,
                 "is_setting_mode": advertisement.is_setting_mode,
+                "is_dormant": advertisement.is_dormant,
                 "battery": advertisement.battery,
                 "lock_mac": advertisement.lock_mac,
             }

--- a/custom_components/ttlock_ble/manifest.json
+++ b/custom_components/ttlock_ble/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/roquerodrigo/ha-ttlock-ble/issues",
   "requirements": [
-    "ttlock-ble==0.1.11"
+    "ttlock-ble==0.2.0"
   ],
   "version": "3.6.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
     "pytest-cov==7.1.0",
     "pytest-homeassistant-custom-component==0.13.354",
     "serialx==1.8.2",
-    "ttlock-ble==0.1.11",
+    "ttlock-ble==0.2.0",
 ]
 lint = [
     "ruff==0.16.4",

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -101,3 +101,32 @@ async def test_undecodable_advertisement_does_not_poll_once_state_is_known(
     instance._async_on_advertisement(MAC, service_info({0x004C: b"\x02\x15"}), None)
     await hass.async_block_till_done()
     coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_dormant_advertisement_still_reaches_the_coordinator(tracker) -> None:
+    """Battery stays usable while the lock is asleep, even without a bolt position."""
+    instance, coordinator = tracker
+    instance._async_on_advertisement(MAC, service_info(manufacturer_data(0x10)), None)
+    _mac, advertisement = coordinator.async_apply_advertisement.call_args.args
+    assert advertisement.is_dormant is True
+    assert advertisement.lock_state is None
+    assert advertisement.battery == 77
+
+
+async def test_dormant_advertisement_falls_back_to_a_poll(tracker, hass) -> None:
+    """A frame with no bolt position bootstraps the same way an undecodable one does."""
+    instance, coordinator = tracker
+    instance._async_on_advertisement(MAC, service_info(manufacturer_data(0x10)), None)
+    await hass.async_block_till_done()
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_dormant_advertisement_does_not_poll_once_state_is_known(
+    tracker,
+    hass,
+) -> None:
+    instance, coordinator = tracker
+    coordinator.async_has_state = MagicMock(return_value=True)
+    instance._async_on_advertisement(MAC, service_info(manufacturer_data(0x10)), None)
+    await hass.async_block_till_done()
+    coordinator.async_request_refresh.assert_not_awaited()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -97,16 +97,21 @@ async def test_coordinator_polls_every_connection_once(
         conn.async_query_state.assert_awaited_once()
 
 
-def _advertisement(*, unlocked: bool, battery: int = 66):
+def _advertisement(*, unlocked: bool, battery: int = 66, dormant: bool = False):
     from ttlock_ble import LockAdvertisement, LockState
 
+    if dormant:
+        lock_state = None
+    else:
+        lock_state = LockState.UNLOCKED if unlocked else LockState.LOCKED
     return LockAdvertisement(
         protocol_type=5,
         protocol_version=3,
         scene=2,
-        lock_state=LockState.UNLOCKED if unlocked else LockState.LOCKED,
+        lock_state=lock_state,
         has_new_records=False,
         is_setting_mode=False,
+        is_dormant=dormant,
         battery=battery,
         lock_mac="AA:BB:CC:DD:EE:FF",
     )
@@ -136,6 +141,34 @@ async def test_apply_advertisement_keeps_the_other_locks(hass) -> None:
     )
     assert coordinator.data["OTHER"] == {"locked": None}
     assert coordinator.data["AA:BB:CC:DD:EE:FF"]["locked"] is True
+
+
+async def test_dormant_advertisement_keeps_the_last_known_state(hass) -> None:
+    """The dormancy bit clears the bolt bit with the radio, not with the bolt."""
+    coordinator = _coordinator(hass, {})
+    coordinator.async_apply_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        _advertisement(unlocked=True, battery=66),
+    )
+    coordinator.async_apply_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        _advertisement(unlocked=False, battery=64, dormant=True),
+    )
+    state = coordinator.data["AA:BB:CC:DD:EE:FF"]
+    assert state["locked"] is False
+    assert state["battery_level"] == 64
+
+
+async def test_dormant_advertisement_reports_no_state_when_none_is_known(hass) -> None:
+    coordinator = _coordinator(hass, {})
+    coordinator.async_apply_advertisement(
+        "AA:BB:CC:DD:EE:FF",
+        _advertisement(unlocked=False, dormant=True),
+    )
+    state = coordinator.data["AA:BB:CC:DD:EE:FF"]
+    assert state["locked"] is None
+    assert state["battery_level"] == 66
+    assert coordinator.async_has_state("AA:BB:CC:DD:EE:FF") is False
 
 
 async def test_has_state_is_false_until_a_lock_state_is_known(hass) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,7 @@ wheels = [
 
 [[package]]
 name = "ha-ttlock-ble"
-version = "3.5.0"
+version = "3.6.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -1155,7 +1155,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.354" },
     { name = "serialx", specifier = "==1.8.2" },
-    { name = "ttlock-ble", specifier = "==0.1.11" },
+    { name = "ttlock-ble", specifier = "==0.2.0" },
 ]
 lint = [
     { name = "mypy", specifier = "==2.3.1" },
@@ -2734,7 +2734,7 @@ wheels = [
 
 [[package]]
 name = "ttlock-ble"
-version = "0.1.11"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
@@ -2742,9 +2742,9 @@ dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/df/0fadbaf14c39a799e85a950c7c760e0d6db1754c7984ddf2ed7b3c11c180/ttlock_ble-0.1.11.tar.gz", hash = "sha256:21af2da1d62fec8cc6e52c85b9e9ad1d41be5aca544a37713c5105dd5422bc68", size = 44280, upload-time = "2026-08-07T18:46:36.407Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/49/a686388fe10fce1481f3c59915cd8b2fb96d93347b79ee2a7e2af4e35464/ttlock_ble-0.2.0.tar.gz", hash = "sha256:3247f8c9749102e64a511187ff87174e407a1f9c6af6e99e1901af6baa25cc12", size = 47744, upload-time = "2026-08-25T23:49:32.255Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/4c/376161dfafbf51200c6659064096654fdc8af8319ce30268e4934ba100a1/ttlock_ble-0.1.11-py3-none-any.whl", hash = "sha256:9d25a0a00f6afbcf3693d5cea781a74f75aa251e29349c3da2d7d6bf9e02e83e", size = 56254, upload-time = "2026-08-07T18:46:35.488Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/dd/75fc1708345e096cd80cdf4890c6e71b406efb84ce8c5538364b01683f9b/ttlock_ble-0.2.0-py3-none-any.whl", hash = "sha256:996833038f1604ba811a3cb3d8db8e8b5dad01557794bd1289ab733663e5d511", size = 61613, upload-time = "2026-08-25T23:49:31.171Z" },
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ name = "winrt-runtime"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/dd/acdd527c1d890c8f852cc2af644aa6c160974e66631289420aa871b05e65/winrt_runtime-3.2.1.tar.gz", hash = "sha256:c8dca19e12b234ae6c3dadf1a4d0761b51e708457492c13beb666556958801ea", size = 21721, upload-time = "2025-06-06T14:40:27.593Z" }
 wheels = [
@@ -2958,7 +2958,7 @@ name = "winrt-windows-devices-bluetooth"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/a0/1c8a0c469abba7112265c6cb52f0090d08a67c103639aee71fc690e614b8/winrt_windows_devices_bluetooth-3.2.1.tar.gz", hash = "sha256:db496d2d92742006d5a052468fc355bf7bb49e795341d695c374746113d74505", size = 23732, upload-time = "2025-06-06T14:41:20.489Z" }
 wheels = [
@@ -2972,7 +2972,7 @@ name = "winrt-windows-devices-bluetooth-advertisement"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/fc/7ffe66ca4109b9e994b27c00f3d2d506e6e549e268791f755287ad9106d8/winrt_windows_devices_bluetooth_advertisement-3.2.1.tar.gz", hash = "sha256:0223852a7b7fa5c8dea3c6a93473bd783df4439b1ed938d9871f947933e574cc", size = 16906, upload-time = "2025-06-06T14:41:21.448Z" }
 wheels = [
@@ -2986,7 +2986,7 @@ name = "winrt-windows-devices-bluetooth-genericattributeprofile"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/21/aeeddc0eccdfbd25e543360b5cc093233e2eab3cdfb53ad3cabae1b5d04d/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1.tar.gz", hash = "sha256:cdf6ddc375e9150d040aca67f5a17c41ceaf13a63f3668f96608bc1d045dde71", size = 38896, upload-time = "2025-06-06T14:41:22.687Z" }
 wheels = [
@@ -3000,7 +3000,7 @@ name = "winrt-windows-devices-enumeration"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/dd/75835bfbd063dffa152109727dedbd80f6e92ea284855f7855d48cdf31c9/winrt_windows_devices_enumeration-3.2.1.tar.gz", hash = "sha256:df316899e39bfc0ffc1f3cb0f5ee54d04e1d167fbbcc1484d2d5121449a935cf", size = 23538, upload-time = "2025-06-06T14:41:26.787Z" }
 wheels = [
@@ -3014,7 +3014,7 @@ name = "winrt-windows-devices-radios"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/02/9704ea359ad8b0d6faa1011f98fb477e8fb6eac5201f39d19e73c2407e7b/winrt_windows_devices_radios-3.2.1.tar.gz", hash = "sha256:4dc9b9d1501846049eb79428d64ec698d6476c27a357999b78a8331072e18a0b", size = 5908, upload-time = "2025-06-06T14:41:44.868Z" }
 wheels = [
@@ -3028,7 +3028,7 @@ name = "winrt-windows-foundation"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/55/098ce7ea0679efcc1298b269c48768f010b6c68f90c588f654ec874c8a74/winrt_windows_foundation-3.2.1.tar.gz", hash = "sha256:ad2f1fcaa6c34672df45527d7c533731fdf65b67c4638c2b4aca949f6eec0656", size = 30485, upload-time = "2025-06-06T14:41:53.344Z" }
 wheels = [
@@ -3042,7 +3042,7 @@ name = "winrt-windows-foundation-collections"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/62/d21e3f1eeb8d47077887bbf0c3882c49277a84d8f98f7c12bda64d498a07/winrt_windows_foundation_collections-3.2.1.tar.gz", hash = "sha256:0eff1ad0d8d763ad17e9e7bbd0c26a62b27215016393c05b09b046d6503ae6d5", size = 16043, upload-time = "2025-06-06T14:41:53.983Z" }
 wheels = [
@@ -3056,7 +3056,7 @@ name = "winrt-windows-storage-streams"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime" },
+    { name = "winrt-runtime", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/50/f4488b07281566e3850fcae1021f0285c9653992f60a915e15567047db63/winrt_windows_storage_streams-3.2.1.tar.gz", hash = "sha256:476f522722751eb0b571bc7802d85a82a3cae8b1cce66061e6e758f525e7b80f", size = 34335, upload-time = "2025-06-06T14:43:23.905Z" }
 wheels = [


### PR DESCRIPTION
> **Blocked on `roquerodrigo/ttlock-ble#66`.** CI is expected to fail here until that fix is released to PyPI and the pin is bumped — the current `ttlock-ble==0.1.11` has no `is_dormant` field. Draft until then.

Closes #52.

## Problem

A dormant lock clears the bolt bit of its advertisement along with its radio, so the payload is indistinguishable from a locked one. `async_apply_advertisement` adopted it verbatim, and since a lock goes dormant roughly one to two minutes after the last activity, the entity reported that the lock had re-locked itself shortly after every unlock — while the bolt had not moved.

Locks with a short auto-lock delay never exposed this, because they never stay unlocked long enough to go dormant. With auto-lock disabled it reproduces on every unlock.

Verified against a real lock: the entity flipped to `locked` on the first dormant advertisement after an unlock, with no operation-log record and no command in flight.

## Change

- An advertisement without a bolt position refreshes only the battery and leaves the last known state in place.
- While no state is known at all, such a frame falls through to the bootstrap poll, exactly as a payload that does not decode already did.
- The poll is still rescheduled on dormant frames: a dormant lock refuses BLE connections, so a round trip has nothing to add.
- Diagnostics gains `is_dormant` and reports `lock_state` as `null` for those frames, so the raw bytes and the decode agree in a dump.

The alternative discussed in #52 — holding the previous value and confirming every claimed transition with a `query_state()` round trip — was not taken: a dormant lock refuses connections, so the confirmation cannot complete precisely when it is needed, and it would trade a wrong value for a silently stale one while spending a BLE session per transition.

## Verification

`ruff format --check`, `ruff check`, `mypy` and the full suite pass at 100% coverage. Validated on a live instance: with the fix loaded, a dormant advertisement logs `lock_state=UNKNOWN dormant=True` and leaves the entity's `last_updated` untouched, where it previously wrote `LOCKED` over it.