### PR TITLE
feat(advertisement): read the operation log while records are pending

### DIFF
--- a/custom_components/ttlock_ble/coordinator.py
+++ b/custom_components/ttlock_ble/coordinator.py
@@ -9,11 +9,14 @@ connections itself.
 State also arrives without any poll: `async_apply_advertisement`
 publishes what `TtlockBleAdvertisementTracker` decodes from the lock's
 advertisements, which is the only channel that reports an auto-lock.
+The same advertisements announce that the lock has unsynced operation
+records, and that flag is what schedules an out-of-band log read.
 """
 
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import TYPE_CHECKING
 
 from homeassistant.core import callback
@@ -41,6 +44,12 @@ if TYPE_CHECKING:
 LOCK_STATE_LOCKED = 0
 LOCK_STATE_UNLOCKED = 1
 
+# How long to leave a lock alone between operation-log reads while it
+# keeps advertising unsynced records. Reaching an idle lock takes several
+# connect attempts, so reads have to be spaced or the adapter would be
+# busy for as long as the records stay unread.
+LOG_RETRY_COOLDOWN_SECONDS = 300.0
+
 
 class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinatorData"]):
     """Periodically poll BLE state via each lock's persistent connection."""
@@ -61,6 +70,8 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
             update_interval=scan_interval,
         )
         self._connections = connections
+        self._log_fetches: set[str] = set()
+        self._log_retry_after: dict[str, float] = {}
 
     @property
     def connections(self) -> dict[str, TtlockBleConnection]:
@@ -89,8 +100,9 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
         clears that bit along with the radio, so the payload is
         indistinguishable from a locked one — and only its battery is
         adopted, leaving whatever state was last known in place. The
-        poll is still rescheduled: a dormant lock refuses connections,
-        so there is nothing a round trip could add.
+        poll is still rescheduled: an idle lock takes several connect
+        attempts to reach, and its own advertisements report the state
+        again as soon as it wakes.
         """
         state_name = (
             "UNKNOWN"
@@ -115,6 +127,76 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
             "battery_level": advertisement.battery,
         }
         self.async_set_updated_data({**(self.data or {}), mac: snapshot})
+        self._async_sync_operation_log(mac, advertisement)
+
+    @callback
+    def _async_sync_operation_log(
+        self,
+        mac: str,
+        advertisement: LockAdvertisement,
+    ) -> None:
+        """
+        Read the operation log while the lock advertises unsynced records.
+
+        The lock raises this flag for anything it recorded and lowers it
+        once its cursor is synced, so it doubles as the acknowledgement:
+        a read that worked is visible as the flag going away, and one
+        that did not is visible as it staying up. Reacting to the level
+        rather than to its rising edge is what makes that usable —
+        `async_get_operation_log` reports an unreachable lock by
+        returning nothing rather than by raising, so an edge would be
+        consumed by a read that never happened and the record would sit
+        there until something else went looking for it.
+
+        `_log_retry_after` keeps the level from becoming a session per
+        advertisement: one read is started, and the next is not
+        considered until the cooldown expires. Seeing the flag down
+        clears it, so a record written right after a successful read is
+        still picked up immediately rather than waiting out a cooldown
+        it has no reason to serve.
+
+        Dormancy is not a reason to skip. A lock that went back to sleep
+        still advertises what it holds, and that is the common case for
+        anything done at the door: reaching it then costs several
+        connect attempts, but it does answer.
+        """
+        if not advertisement.has_new_records:
+            self._log_retry_after.pop(mac, None)
+            return
+        connection = self._connections.get(mac)
+        if connection is None or mac in self._log_fetches:
+            return
+        now = time.monotonic()
+        if now < self._log_retry_after.get(mac, 0.0):
+            return
+        self._log_retry_after[mac] = now + LOG_RETRY_COOLDOWN_SECONDS
+        self._log_fetches.add(mac)
+        self.config_entry.async_create_task(
+            self.hass,
+            self._async_fetch_operation_log(mac, connection),
+            name=f"{DOMAIN}.advertised_operation_log.{mac}",
+        )
+
+    async def _async_fetch_operation_log(
+        self,
+        mac: str,
+        connection: TtlockBleConnection,
+    ) -> None:
+        """Read the log once so the connection dispatches whatever is new."""
+        LOGGER.debug("Advertised records pending for %s, reading the log", mac)
+        try:
+            await connection.async_get_operation_log()
+        except Exception:  # noqa: BLE001
+            # Reaching an idle lock takes several attempts, so a failed
+            # read is routine; the lock keeps advertising the records
+            # until one of them lands.
+            LOGGER.debug(
+                "Advertised operation-log read failed for %s",
+                mac,
+                exc_info=True,
+            )
+        finally:
+            self._log_fetches.discard(mac)
 
     async def _async_update_data(self) -> TtlockBleCoordinatorData:
         """Poll every connection once and return the aggregated state map."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -97,7 +98,13 @@ async def test_coordinator_polls_every_connection_once(
         conn.async_query_state.assert_awaited_once()
 
 
-def _advertisement(*, unlocked: bool, battery: int = 66, dormant: bool = False):
+def _advertisement(
+    *,
+    unlocked: bool,
+    battery: int = 66,
+    dormant: bool = False,
+    records: bool = False,
+):
     from ttlock_ble import LockAdvertisement, LockState
 
     if dormant:
@@ -109,12 +116,21 @@ def _advertisement(*, unlocked: bool, battery: int = 66, dormant: bool = False):
         protocol_version=3,
         scene=2,
         lock_state=lock_state,
-        has_new_records=False,
+        has_new_records=records,
         is_setting_mode=False,
         is_dormant=dormant,
         battery=battery,
         lock_mac="AA:BB:CC:DD:EE:FF",
     )
+
+
+def _task_entry(hass) -> MagicMock:
+    """A config entry whose `async_create_task` really schedules the coroutine."""
+    entry = MagicMock()
+    entry.async_create_task = lambda _hass, coro, name=None: hass.async_create_task(  # noqa: ARG005
+        coro,
+    )
+    return entry
 
 
 async def test_apply_advertisement_publishes_state_without_polling(
@@ -199,3 +215,103 @@ async def test_poll_that_raises_blanks_only_that_lock(hass, sample_virtual_key) 
     data = await coordinator._async_update_data()
     assert data[sample_virtual_key.lockMac] == {"locked": None, "battery_level": None}
     assert data[other]["locked"] is False
+
+
+MAC = "AA:BB:CC:DD:EE:FF"
+
+
+def _log_coordinator(hass, conn):
+    coordinator = _coordinator(hass, {MAC: conn})
+    coordinator.config_entry = _task_entry(hass)
+    return coordinator
+
+
+async def test_advertised_records_trigger_a_log_read(hass) -> None:
+    """A keypad unlock reaches the event entity without waiting for the poll."""
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    coordinator.async_apply_advertisement(
+        MAC, _advertisement(unlocked=False, records=True)
+    )
+    await hass.async_block_till_done()
+    conn.async_get_operation_log.assert_awaited_once()
+
+
+async def test_advertised_records_read_once_per_cooldown(hass) -> None:
+    """The flag stays up until the cursor syncs; reads must be spaced, not repeated."""
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    for _ in range(3):
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, records=True)
+        )
+        await hass.async_block_till_done()
+    conn.async_get_operation_log.assert_awaited_once()
+
+
+async def test_unreachable_lock_is_retried_after_the_cooldown(hass) -> None:
+    """An unreachable lock reports nothing rather than raising, keeping the flag up."""
+    conn = _mock_connection()
+    conn.async_get_operation_log = AsyncMock(return_value=[])
+    coordinator = _log_coordinator(hass, conn)
+    coordinator.async_apply_advertisement(
+        MAC, _advertisement(unlocked=False, records=True)
+    )
+    await hass.async_block_till_done()
+    coordinator._log_retry_after[MAC] = time.monotonic() - 1
+    coordinator.async_apply_advertisement(
+        MAC, _advertisement(unlocked=False, records=True)
+    )
+    await hass.async_block_till_done()
+    assert conn.async_get_operation_log.await_count == 2
+
+
+async def test_flag_going_down_clears_the_cooldown(hass) -> None:
+    """A record written right after a successful read must not wait one out."""
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    for records in (True, False, True):
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, records=records)
+        )
+        await hass.async_block_till_done()
+    assert conn.async_get_operation_log.await_count == 2
+
+
+async def test_advertisement_without_records_reads_nothing(hass) -> None:
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    coordinator.async_apply_advertisement(MAC, _advertisement(unlocked=True))
+    await hass.async_block_till_done()
+    conn.async_get_operation_log.assert_not_awaited()
+
+
+async def test_dormant_advertisement_still_reads_the_log(hass) -> None:
+    """Anything done at the door is recorded, then the lock goes back to sleep."""
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    coordinator.async_apply_advertisement(
+        MAC, _advertisement(unlocked=False, dormant=True, records=True)
+    )
+    await hass.async_block_till_done()
+    conn.async_get_operation_log.assert_awaited_once()
+
+
+async def test_advertised_log_read_failure_is_contained(hass) -> None:
+    conn = _mock_connection()
+    conn.async_get_operation_log = AsyncMock(side_effect=RuntimeError("link dropped"))
+    coordinator = _log_coordinator(hass, conn)
+    coordinator.async_apply_advertisement(
+        MAC, _advertisement(unlocked=False, records=True)
+    )
+    await hass.async_block_till_done()
+    conn.async_get_operation_log.assert_awaited_once()
+
+
+async def test_advertised_records_for_an_unknown_lock_are_ignored(hass) -> None:
+    coordinator = _coordinator(hass, {})
+    coordinator.config_entry = _task_entry(hass)
+    coordinator.async_apply_advertisement(
+        "11:22:33:44:55:66", _advertisement(unlocked=False, records=True)
+    )
+    await hass.async_block_till_done()


### PR DESCRIPTION
## Problem

Every advertisement carries a flag saying the lock holds unsynced operation records. It was decoded and only ever surfaced in the diagnostics dump — nothing acted on it. The operation log was read on the scheduled poll and shortly after each command, so an unlock from the keypad or a fingerprint reached the event entity no earlier than the next poll. On an idle lock that poll frequently times out, because reaching one takes several connect attempts.

## Change

The flag now drives the read, as a **level** rather than as a rising edge.

That distinction is load-bearing. The lock lowers the flag only once its cursor is synced, which makes it the sole acknowledgement available: `async_get_operation_log` reports an unreachable lock by returning nothing rather than by raising, so an edge is consumed by a read that never happened, and the record sits on the lock until something else goes looking for it. Reacting to the level makes a failed read self-correcting — the flag is still up on the next advertisement.

`_log_retry_after` keeps the level from becoming a BLE session per advertisement: one read is started, and the next is not considered until the cooldown expires. Seeing the flag down clears the cooldown, so a record written right after a successful read is picked up immediately instead of waiting out a cooldown it has no reason to serve.

Dormancy is deliberately not a reason to skip. A lock that went back to sleep still advertises what it holds, and that is the common case for anything done at the door: reaching it then costs several connect attempts, but it does answer.

## Verification

`ruff format --check`, `ruff check`, `mypy` and the full suite pass at 100% coverage.

Validated on a live instance, including both failure modes:

```
21:17:38  Advertised state ... dormant=True
21:17:38  Advertised records pending ..., reading the log     <- fires on a dormant frame
21:18:31  get_operation_log: 1 entries                        <- reached the lock, 53s
21:18:43  flag down, no re-trigger                            <- cursor synced
```

A later read hit the silent-failure path, which is what motivated the level semantics:

```
21:20:39  Advertised records pending ..., reading the log
21:24:24  Failed to connect after 9 attempt(s) ...
21:24:24  get_operation_log: no client                        <- returns [], does not raise
21:25:36  advertisement still carries the flag, no re-trigger <- edge consumed, record stranded
```

End-to-end delivery of a record created at the door was confirmed separately: a `fr_unlock_succeed` entry reached the event entity, with the backlog-seeding pass behaving as designed on the first successful read after a restart.