### PR TITLE
fix(event): persist the operation-log cursor across restarts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,13 @@ lock.py          → LockEntity backed by the BLE connection
 sensor.py        → BatterySensor backed by the same poll + push events
 binary_sensor.py → connectivity BinarySensorEntity reflecting live BLE link state
 event.py         → EventEntity that surfaces decoded LogEntry records
+record_store.py  → persists the operation-log cursor per lock, so a
+                    restart resumes instead of re-seeding
 ```
 
 ### Entry typing
 
-`data/` is a package, one class per file, re-exported from `data/__init__.py`. `data/__init__.py` defines `TtlockBleConfigEntry = ConfigEntry[TtlockBleData]`; `data/runtime.py` defines the `TtlockBleData(keys, virtual_keys, connections, coordinator, bluetooth_unsubs, first_refresh)` dataclass. State lives on `entry.runtime_data` (auto-discarded on unload), never on `hass.data`.
+`data/` is a package, one class per file, re-exported from `data/__init__.py`. `data/__init__.py` defines `TtlockBleConfigEntry = ConfigEntry[TtlockBleData]`; `data/runtime.py` defines the `TtlockBleData(keys, virtual_keys, connections, coordinator, bluetooth_unsubs, first_refresh)` dataclass; `data/log_cursor.py` defines `TtlockBleLogCursor(records, seeded, on_move)`, which `record_store.py` fills and each connection resumes its operation log from. State lives on `entry.runtime_data` (auto-discarded on unload), never on `hass.data`.
 
 ### Config flow surface
 
@@ -123,7 +125,7 @@ Every cloud call in the flow, `_async_fetch_keys` included, maps its exceptions 
 - A reconnect maintain loop driven by an `asyncio.Event` the SDK's `disconnected_callback` toggles.
 - A post-drop cooldown: after any disconnect, sleeps the `reconnect_cooldown_seconds` the constructor received (from the `reconnect_interval` option; `0` when `permanent_connection` is on) before reconnecting — no immediate retry unless configured so. **The cooldown paces that loop only.** It used to also veto `async_query_state`, and since the lock drops every idle session within seconds the loop re-armed it constantly, so the configured `scan_interval` never actually ran a poll (issue #42). Reads are rate-limited by their own callers instead.
 - A dispatcher forwarder: any push event the SDK emits is fanned out on `ttlock_ble_event_<mac>` so the lock, sensor, and event entities can subscribe. The BLE drop is announced from bleak's own callback, not from the teardown that follows the cooldown, so the connectivity sensor does not claim a live link for five minutes after the link died.
-- Backlog seeding: the first operation-log fetch that actually reaches the lock only fills `_seen_records` and dispatches nothing. The lock returns everything unsynced since its last cursor sync, and replaying that history as live events would fire automations for unlocks from days ago. Tying it to a *successful* fetch matters — a lock out of range at startup must not spend its seeding pass on a poll that read nothing.
+- Backlog seeding: on a lock with no restored cursor, the first operation-log fetch that actually reaches it only fills `_seen_records` and dispatches nothing. The lock returns everything unsynced since its last cursor sync, and replaying that history as live events would fire automations for unlocks from days ago. Tying it to a *successful* fetch matters — a lock out of range at setup must not spend its seeding pass on a poll that read nothing. `record_store.py` persists the cursor, so the pass runs once per lock rather than once per HA start; keying it to the start is what made a restart swallow whatever happened at the door just after it.
 - A refusal to reconnect after `async_stop`: a late caller would otherwise take the lock's single central slot with no maintain loop left to release it.
 
 ### Passive advertisement tracking

--- a/custom_components/ttlock_ble/__init__.py
+++ b/custom_components/ttlock_ble/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from functools import partial
 from typing import TYPE_CHECKING, cast
 
 from homeassistant.const import CONF_SCAN_INTERVAL, Platform
@@ -28,7 +29,8 @@ from .const import (
     LOGGER,
 )
 from .coordinator import TtlockBleDataUpdateCoordinator
-from .data import TtlockBleData
+from .data import TtlockBleData, TtlockBleLogCursor
+from .record_store import TtlockBleRecordStore
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -116,11 +118,18 @@ async def async_setup_entry(
             ),
         )
     )
+    record_store = TtlockBleRecordStore(hass)
+    await record_store.async_load()
     connections: dict[str, TtlockBleConnection] = {
         key.lockMac: TtlockBleConnection(
             hass,
             key,
             reconnect_cooldown_seconds=reconnect_cooldown_seconds,
+            log_cursor=TtlockBleLogCursor(
+                records=record_store.seen(key.lockMac),
+                seeded=record_store.is_seeded(key.lockMac),
+                on_move=partial(record_store.async_remember, key.lockMac),
+            ),
         )
         for key in virtual_keys
     }

--- a/custom_components/ttlock_ble/connection.py
+++ b/custom_components/ttlock_ble/connection.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from ttlock_ble import TTLockClient, TTLockError
 
 from .const import DEFAULT_RECONNECT_INTERVAL_SECONDS, DOMAIN, LOGGER
+from .data import TtlockBleLogCursor
 
 if TYPE_CHECKING:
     from bleak import BleakClient
@@ -67,6 +68,7 @@ class TtlockBleConnection:
         hass: HomeAssistant,
         key: VirtualKey,
         reconnect_cooldown_seconds: float = DEFAULT_RECONNECT_INTERVAL_SECONDS,
+        log_cursor: TtlockBleLogCursor | None = None,
     ) -> None:
         """
         Bind to the HA instance and the credentials for a single lock.
@@ -74,6 +76,10 @@ class TtlockBleConnection:
         `reconnect_cooldown_seconds` paces the maintain loop after a BLE
         drop; `0` means reconnect immediately, keeping the session
         permanently open at the cost of the lock's battery.
+
+        `log_cursor` restores where the operation log was last read, so
+        the backlog pass below is not repeated after a restart and new
+        records are dispatched straight away.
         """
         self._hass = hass
         self._key = key
@@ -83,8 +89,10 @@ class TtlockBleConnection:
         self._task: asyncio.Task[None] | None = None
         self._closing = False
         self._disconnected = asyncio.Event()
-        self._seen_records: set[int] = set()
-        self._log_seeded = False
+        cursor = log_cursor or TtlockBleLogCursor()
+        self._seen_records: set[int] = set(cursor.records)
+        self._log_seeded = cursor.seeded
+        self._on_records_seen = cursor.on_move
         self._broadcast_connected = False
 
     @property
@@ -156,17 +164,21 @@ class TtlockBleConnection:
         """
         Fetch operation records from the lock and dispatch the new ones.
 
-        The first fetch that actually reaches the lock only seeds
-        `_seen_records` and returns nothing. The lock hands back
-        everything unsynced since its last cursor sync, and that set is
-        history — replaying it through the event entity would fire
-        automations for unlocks that happened days ago. `_seen_records`
-        lives in memory, so the seeding pass runs once per HA start,
-        which is exactly when the backlog would otherwise arrive.
+        On a lock with no restored cursor, the first fetch that actually
+        reaches it only seeds `_seen_records` and returns nothing. The
+        lock hands back everything unsynced since its last cursor sync,
+        and that set is history — replaying it through the event entity
+        would fire automations for unlocks that happened days ago.
+
+        That pass runs once per lock, not once per Home Assistant start:
+        the cursor is persisted, so a restart resumes where the previous
+        run stopped. Tying it to the start instead is what used to make
+        a restart swallow whatever happened at the door just after it,
+        which is neither history nor something to replay.
 
         Seeding is tied to a successful fetch, not to an attempt: a lock
-        out of range at startup gets its seeding pass whenever it first
-        answers.
+        out of range on first setup gets its seeding pass whenever it
+        first answers.
         """
         async with self._lock:
             client = await self._async_ensure_connected_locked()
@@ -202,8 +214,11 @@ class TtlockBleConnection:
             if entry.record_number not in self._seen_records:
                 self._seen_records.add(entry.record_number)
                 new_entries.append(entry)
-        if not self._log_seeded:
-            self._log_seeded = True
+        seeding = not self._log_seeded
+        self._log_seeded = True
+        if (new_entries or seeding) and self._on_records_seen is not None:
+            self._on_records_seen(self._seen_records)
+        if seeding:
             LOGGER.debug(
                 "Lock %s: seeded %d existing log records, none dispatched",
                 self._key.lockMac,

--- a/custom_components/ttlock_ble/data/__init__.py
+++ b/custom_components/ttlock_ble/data/__init__.py
@@ -18,6 +18,7 @@ from .diagnostics_lock_summary import TtlockBleDiagnosticsLockSummary
 from .diagnostics_payload import TtlockBleDiagnosticsPayload
 from .lock_event_attributes import TtlockBleLogEventAttributes
 from .lock_state import TtlockBleLockState
+from .log_cursor import TtlockBleLogCursor
 from .manual_key_input import TtlockBleManualKeyInput
 from .options_data import TtlockBleOptionsData
 from .runtime import TtlockBleData
@@ -44,6 +45,7 @@ __all__ = [
     "TtlockBleDiagnosticsLockSummary",
     "TtlockBleDiagnosticsPayload",
     "TtlockBleLockState",
+    "TtlockBleLogCursor",
     "TtlockBleLogEventAttributes",
     "TtlockBleManualKeyInput",
     "TtlockBleOptionsData",

--- a/custom_components/ttlock_ble/data/log_cursor.py
+++ b/custom_components/ttlock_ble/data/log_cursor.py
@@ -1,0 +1,29 @@
+"""Where a lock's operation log was last read, handed to its connection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True, slots=True)
+class TtlockBleLogCursor:
+    """
+    A lock's place in its operation log, restored from a previous run.
+
+    `seeded` is carried separately from `records` because the two are
+    not the same fact: a lock whose log was already synced seeds an
+    empty set, and an empty set is indistinguishable from never having
+    looked. Without the flag such a lock repeats its backlog pass after
+    every restart and keeps swallowing its first real record.
+
+    `on_move` is called with the full set whenever it grows, so the
+    caller can persist it.
+    """
+
+    records: set[int] = field(default_factory=set)
+    seeded: bool = False
+    on_move: Callable[[set[int]], None] | None = None

--- a/custom_components/ttlock_ble/record_store.py
+++ b/custom_components/ttlock_ble/record_store.py
@@ -1,0 +1,91 @@
+"""Persisted operation-log cursor for ttlock_ble."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+STORAGE_VERSION = 1
+STORAGE_KEY = f"{DOMAIN}.records"
+SAVE_DELAY_SECONDS = 10
+
+# Record ids kept per lock. The firmware hands back everything unsynced
+# since its last cursor sync, so only the recent end of the log is ever
+# compared against; the cap keeps the file from growing for the lifetime
+# of the lock.
+MAX_RECORDS_PER_LOCK = 250
+
+
+class TtlockBleStoredCursor(TypedDict):
+    """One lock's place in its operation log, as written to storage."""
+
+    seeded: bool
+    records: list[int]
+
+
+class TtlockBleRecordStore:
+    """
+    Remember which operation records each lock has already reported.
+
+    Without this the set lives only in memory, so every Home Assistant
+    restart forgot where the log had been read up to. The lock answers a
+    fetch with everything unsynced since its own cursor sync, which can
+    be days of history, so the integration had to discard the whole
+    first fetch after each start to avoid replaying it — and that
+    discarded genuinely new records too, whenever something happened at
+    the door shortly after a restart.
+
+    `seeded` is stored separately from the ids because the two are not
+    the same fact. A lock whose log was already synced seeds an empty
+    set, and an empty set is indistinguishable from never having looked;
+    without the flag that lock would seed again after every restart and
+    keep swallowing its first real record.
+
+    Keyed by MAC rather than by entry so a lock keeps its cursor across
+    a reconfigure, and the ids are stored rather than a high-water mark
+    because the firmware's numbering is not guaranteed to be monotonic.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Bind the cursor to HA's storage helper."""
+        self._store: Store[dict[str, TtlockBleStoredCursor]] = Store(
+            hass,
+            STORAGE_VERSION,
+            STORAGE_KEY,
+        )
+        self._cursors: dict[str, TtlockBleStoredCursor] = {}
+
+    async def async_load(self) -> None:
+        """Read the persisted cursors, tolerating a missing or empty file."""
+        data = await self._store.async_load()
+        if not data:
+            return
+        self._cursors = dict(data)
+
+    def seen(self, mac: str) -> set[int]:
+        """Return the record ids already reported for `mac`."""
+        cursor = self._cursors.get(mac)
+        return set(cursor["records"]) if cursor else set()
+
+    def is_seeded(self, mac: str) -> bool:
+        """Report whether `mac` has already had its backlog pass."""
+        cursor = self._cursors.get(mac)
+        return bool(cursor and cursor["seeded"])
+
+    def async_remember(self, mac: str, seen: set[int]) -> None:
+        """Persist `seen` for `mac`, keeping only the most recent ids."""
+        self._cursors[mac] = {
+            "seeded": True,
+            "records": sorted(seen)[-MAX_RECORDS_PER_LOCK:],
+        }
+        self._store.async_delay_save(self._snapshot, SAVE_DELAY_SECONDS)
+
+    def _snapshot(self) -> dict[str, TtlockBleStoredCursor]:
+        """Render the in-memory cursors as the JSON the store writes."""
+        return dict(self._cursors)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -14,6 +14,7 @@ from custom_components.ttlock_ble.connection import (
     event_signal,
     log_signal,
 )
+from custom_components.ttlock_ble.data import TtlockBleLogCursor
 
 
 def _log_entry(record_number: int) -> SimpleNamespace:
@@ -672,3 +673,93 @@ async def test_run_command_lets_cancellation_through(
     conn = TtlockBleConnection(hass, sample_virtual_key)
     with pytest.raises(asyncio.CancelledError):
         await conn.async_lock()
+
+
+async def test_restored_cursor_dispatches_without_a_seeding_pass(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    """A restart resumes where the previous run stopped, so nothing is swallowed."""
+    received: list[object] = []
+    async_dispatcher_connect(
+        hass,
+        log_signal(sample_virtual_key.lockMac),
+        received.append,
+    )
+    conn = TtlockBleConnection(
+        hass,
+        sample_virtual_key,
+        log_cursor=TtlockBleLogCursor(records={1, 2}, seeded=True),
+    )
+
+    mock_ttlock_client.get_operation_log = AsyncMock(
+        return_value=[_log_entry(1), _log_entry(2), _log_entry(3)],
+    )
+    new_entries = await conn.async_get_operation_log()
+    await hass.async_block_till_done()
+    assert [e.record_number for e in new_entries] == [3]
+    assert [e.record_number for e in received] == [3]
+
+
+async def test_an_empty_restored_cursor_still_seeds(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    """A lock seen for the first time has a backlog that is history, not events."""
+    conn = TtlockBleConnection(
+        hass, sample_virtual_key, log_cursor=TtlockBleLogCursor()
+    )
+    mock_ttlock_client.get_operation_log = AsyncMock(
+        return_value=[_log_entry(1), _log_entry(2)],
+    )
+    assert await conn.async_get_operation_log() == []
+
+
+async def test_the_cursor_is_reported_as_it_moves(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    remembered: list[set[int]] = []
+    conn = TtlockBleConnection(
+        hass,
+        sample_virtual_key,
+        log_cursor=TtlockBleLogCursor(
+            records={1},
+            seeded=True,
+            on_move=lambda seen: remembered.append(set(seen)),
+        ),
+    )
+    mock_ttlock_client.get_operation_log = AsyncMock(
+        return_value=[_log_entry(1), _log_entry(2)],
+    )
+    await conn.async_get_operation_log()
+    assert remembered == [{1, 2}]
+
+
+async def test_the_cursor_is_not_reported_when_nothing_is_new(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    remembered: list[set[int]] = []
+    conn = TtlockBleConnection(
+        hass,
+        sample_virtual_key,
+        log_cursor=TtlockBleLogCursor(
+            records={1, 2},
+            seeded=True,
+            on_move=lambda seen: remembered.append(set(seen)),
+        ),
+    )
+    mock_ttlock_client.get_operation_log = AsyncMock(
+        return_value=[_log_entry(1), _log_entry(2)],
+    )
+    await conn.async_get_operation_log()
+    assert remembered == []

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -223,6 +223,7 @@ async def test_reconnect_options_reach_the_connections(
             hass,
             ANY,
             reconnect_cooldown_seconds=expected_cooldown,
+            log_cursor=ANY,
         )
 
 

--- a/tests/test_record_store.py
+++ b/tests/test_record_store.py
@@ -1,0 +1,82 @@
+"""Coverage for the persisted operation-log cursor."""
+
+from __future__ import annotations
+
+from custom_components.ttlock_ble.record_store import (
+    MAX_RECORDS_PER_LOCK,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+    TtlockBleRecordStore,
+)
+
+MAC = "AA:BB:CC:DD:EE:FF"
+
+
+async def test_load_tolerates_a_missing_file(hass) -> None:
+    store = TtlockBleRecordStore(hass)
+    await store.async_load()
+    assert store.seen(MAC) == set()
+
+
+async def test_load_restores_the_persisted_ids(hass, hass_storage) -> None:
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {MAC: {"seeded": True, "records": [7, 8, 9]}},
+    }
+    store = TtlockBleRecordStore(hass)
+    await store.async_load()
+    assert store.seen(MAC) == {7, 8, 9}
+
+
+async def test_seen_hands_back_a_copy(hass) -> None:
+    """A caller mutating its own set must not silently move the cursor."""
+    store = TtlockBleRecordStore(hass)
+    store.async_remember(MAC, {1, 2})
+    borrowed = store.seen(MAC)
+    borrowed.add(3)
+    assert store.seen(MAC) == {1, 2}
+
+
+async def test_remember_keeps_only_the_most_recent_ids(hass) -> None:
+    store = TtlockBleRecordStore(hass)
+    store.async_remember(MAC, set(range(MAX_RECORDS_PER_LOCK * 2)))
+    kept = store.seen(MAC)
+    assert len(kept) == MAX_RECORDS_PER_LOCK
+    assert max(kept) == MAX_RECORDS_PER_LOCK * 2 - 1
+
+
+async def test_remember_writes_the_delayed_snapshot(hass, hass_storage) -> None:
+    store = TtlockBleRecordStore(hass)
+    store.async_remember(MAC, {3, 1, 2})
+    await store._store.async_save(store._snapshot())
+    assert hass_storage[STORAGE_KEY]["data"] == {
+        MAC: {"seeded": True, "records": [1, 2, 3]}
+    }
+
+
+async def test_locks_keep_separate_cursors(hass) -> None:
+    other = "11:22:33:44:55:66"
+    store = TtlockBleRecordStore(hass)
+    store.async_remember(MAC, {1})
+    store.async_remember(other, {2})
+    assert store.seen(MAC) == {1}
+    assert store.seen(other) == {2}
+
+
+async def test_a_lock_is_not_seeded_until_it_is_remembered(hass) -> None:
+    store = TtlockBleRecordStore(hass)
+    assert store.is_seeded(MAC) is False
+    store.async_remember(MAC, set())
+    assert store.is_seeded(MAC) is True
+
+
+async def test_an_empty_backlog_still_marks_the_lock_seeded(hass, hass_storage) -> None:
+    """A lock whose log was already synced seeds nothing, and must not seed twice."""
+    store = TtlockBleRecordStore(hass)
+    store.async_remember(MAC, set())
+    await store._store.async_save(store._snapshot())
+
+    restored = TtlockBleRecordStore(hass)
+    await restored.async_load()
+    assert restored.seen(MAC) == set()
+    assert restored.is_seeded(MAC) is True


### PR DESCRIPTION
## Problem

The set of records already reported to the event entity lived only in memory, so every Home Assistant restart forgot where the operation log had been read up to.

The lock answers a fetch with everything unsynced since its own cursor sync, which can be days of history, so the first fetch after each start had to be discarded wholesale to avoid replaying it through the event entity and firing automations for unlocks that happened days ago. That discard is indiscriminate: a record written at the door shortly after a restart is neither history nor something to replay, but it arrives in the same fetch and was swallowed with the rest.

## Change

The cursor is persisted per lock, so the backlog pass runs once per lock instead of once per start, and a restart resumes where the previous run stopped.

Two details are load-bearing:

- **`seeded` is stored separately from the record ids.** A lock whose log was already synced seeds an empty set, and an empty set is indistinguishable from never having looked. Without the flag such a lock repeats its backlog pass after every restart and keeps swallowing its first real record — which is the original bug in a different disguise. This was caught in testing, where the first pass legitimately returned zero records and persisted nothing.
- **Record ids are stored rather than a high-water mark**, because the firmware's numbering is not guaranteed to be monotonic. They are capped per lock so the file stays bounded over the life of a lock.

`TtlockBleLogCursor` carries the restored state and the persist callback into `TtlockBleConnection` as one value, keeping the constructor's argument list honest.

## Verification

`ruff format --check`, `ruff check`, `mypy` and the full suite pass at 100% coverage.

Validated on a live instance. A first pass on an already-synced log persists the flag with no ids:

```json
{"E9:...": {"seeded": true, "records": []}}
```

and the fetch after the next restart no longer produces a backlog pass:

```
22:32:06  get_operation_log ...: 0 entries, seen=0        <- no "seeded ... none dispatched"
```

Before this change, every successful fetch after a restart logged `seeded N existing log records, none dispatched` and delivered nothing.

## Relationship to #84

Independent — that one touches `coordinator.py`, this one `connection.py` — but they compound: #84 makes the log be read much sooner after startup, so the seeding pass swallowed fresh records far more reliably than it used to. Both were validated together on a live instance. Either order of merge works.