### PR TITLE
feat(event): classify the record types that fell through to "other"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ The diagnostics dump carries the last advertisement per lock, raw bytes included
 
 ### Event entity
 
-`event.py` republishes decoded `LogEntry` records. The SDK carries keypad codes, card numbers, fingerprint ids and fob MACs in one `password` field; only the first are secret, so `PASSCODE_RECORD_TYPES` lists the record types whose value is a working door code and those never reach an event attribute. An attribute lands in the recorder database and is readable through the API by any user, admin or not.
+`event.py` republishes decoded `LogEntry` records. Every `LogOperate` the SDK knows is accounted for: the four buckets plus `UNBUCKETED_RECORD_TYPES`, an explicit list of records no bucket describes honestly (storage full, reboot, `illegal_unlock`, door left open, a two-factor verification step). A test asserts the union covers the enum, so a record type added to the SDK later fails the suite instead of quietly becoming `other`. Note that an auto-lock produces no record at all — the firmware writes none — which is why the advertisement channel is the only way to see one. The SDK carries keypad codes, card numbers, fingerprint ids and fob MACs in one `password` field; only the first are secret, so `PASSCODE_RECORD_TYPES` lists the record types whose value is a working door code and those never reach an event attribute. An attribute lands in the recorder database and is readable through the API by any user, admin or not.
 
 ### Diagnostics
 

--- a/custom_components/ttlock_ble/entity.py
+++ b/custom_components/ttlock_ble/entity.py
@@ -44,7 +44,7 @@ class TtlockBleEntity(CoordinatorEntity[TtlockBleDataUpdateCoordinator]):
             connections={(CONNECTION_BLUETOOTH, mac)},
             name=self._key.lockAlias or self._key.lockName or self._key.lockMac,
             manufacturer=MANUFACTURER,
-            model=f"protocol {self._key.lockVersion.protocolType}."
+            model=f"Protocol {self._key.lockVersion.protocolType}."
             f"{self._key.lockVersion.protocolVersion}",
         )
 

--- a/custom_components/ttlock_ble/event.py
+++ b/custom_components/ttlock_ble/event.py
@@ -77,6 +77,7 @@ async def async_setup_entry(
 UNLOCK_RECORD_TYPES: frozenset[int] = frozenset(
     {
         LogOperate.MOBILE_UNLOCK,
+        LogOperate.SERVER_UNLOCK,
         LogOperate.KEYBOARD_PASSWORD_UNLOCK,
         LogOperate.IC_UNLOCK_SUCCEED,
         LogOperate.FR_UNLOCK_SUCCEED,
@@ -85,6 +86,22 @@ UNLOCK_RECORD_TYPES: frozenset[int] = frozenset(
         LogOperate.WIRELESS_KEY_FOB,
         LogOperate.WIRELESS_KEY_PAD,
         LogOperate.REMOTE_CONTROL_KEY,
+        LogOperate.OPERATE_KEY_UNLOCK,
+        LogOperate.DOOR_SENSOR_UNLOCK,
+        LogOperate.QR_CODE_UNLOCK_SUCCESS,
+        LogOperate.FACE_3D_UNLOCK_SUCCESS,
+        LogOperate.APP_AUTH_KEY_UNLOCK_SUCCESS,
+        LogOperate.GATEWAY_AUTH_KEY_UNLOCK_SUCCESS,
+        LogOperate.DOUBLE_CHECK_KEY_UNLOCK,
+        LogOperate.DOUBLE_CHECK_PASSCODE_UNLOCK,
+        LogOperate.DOUBLE_CHECK_FINGER_PRINT_UNLOCK,
+        LogOperate.DOUBLE_CHECK_CARD_UNLOCK,
+        LogOperate.DOUBLE_CHECK_FACE_UNLOCK,
+        LogOperate.DOUBLE_CHECK_KEY_FOB_UNLOCK,
+        LogOperate.DOUBLE_CHECK_PALM_VEIN_UNLOCK,
+        LogOperate.PALM_VEIN_UNLOCK_SUCCESS,
+        LogOperate.ADMIN_CODE_UNLOCK,
+        LogOperate.THIRD_DEVICE_UNLOCK_SUCCESS,
     },
 )
 
@@ -94,6 +111,12 @@ LOCK_RECORD_TYPES: frozenset[int] = frozenset(
         LogOperate.PASSCODE_LOCK,
         LogOperate.IC_LOCK,
         LogOperate.FR_LOCK,
+        LogOperate.DOOR_SENSOR_LOCK,
+        LogOperate.OPERATE_KEY_LOCK,
+        LogOperate.APP_DEAD_LOCK,
+        LogOperate.FACE_3D_LOCK,
+        LogOperate.PALM_VEIN_LOCK,
+        LogOperate.THIRD_DEVICE_LOCK_SUCCESS,
     },
 )
 
@@ -107,9 +130,24 @@ UNLOCK_FAILED_RECORD_TYPES: frozenset[int] = frozenset(
         LogOperate.FR_UNLOCK_FAILED_LOCK_REVERSE,
         LogOperate.PASSCODE_EXPIRED,
         LogOperate.PASSCODE_IN_BLACK_LIST,
+        LogOperate.IC_UNLOCK_FAILED,
+        LogOperate.IC_UNLOCK_FAILED_BLACKLIST,
+        LogOperate.QR_CODE_UNLOCK_FAILED,
+        LogOperate.FACE_3D_UNLOCK_FAILED_LOCK_REVERSE,
+        LogOperate.FACE_3D_UNLOCK_FAILED_INVALID_TIME,
+        LogOperate.CPU_CARD_UNLOCK_FAILED,
+        LogOperate.PALM_VEIN_UNLOCK_FAILED_LOCK_REVERSE,
+        LogOperate.PALM_VEIN_UNLOCK_FAILED,
+        LogOperate.CARD_UNLOCK_FAILED,
+        LogOperate.THIRD_DEVICE_UNLOCK_FAILED_LOCK_REVERSE,
+        LogOperate.THIRD_DEVICE_UNLOCK_FAILED_INVALID_TIME,
     },
 )
 
+# Credential management, whatever the credential is. The event type is
+# named after passcodes because that is all the firmware could manage
+# when it was added, and renaming it now would break every automation
+# listening for it.
 PASSWORD_CHANGE_RECORD_TYPES: frozenset[int] = frozenset(
     {
         LogOperate.KEYBOARD_MODIFY_PASSWORD,
@@ -122,6 +160,40 @@ PASSWORD_CHANGE_RECORD_TYPES: frozenset[int] = frozenset(
         LogOperate.DELETE_IC_SUCCEED,
         LogOperate.ADD_FR,
         LogOperate.DELETE_FR_SUCCEED,
+        LogOperate.CLEAR_FR_SUCCEED,
+        LogOperate.FACE_3D_ADD_SUCCESS,
+        LogOperate.FACE_3D_DELETE_SUCCESS,
+        LogOperate.FACE_3D_CLEAR_SUCCESS,
+        LogOperate.PALM_VEIN_ADD_SUCCESS,
+        LogOperate.PALM_VEIN_DELETE_SUCCESS,
+        LogOperate.PALM_VEIN_CLEAR_SUCCESS,
+        LogOperate.ADD_PASSCODE_SUCCESSFULLY,
+        LogOperate.ADD_THIRD_DEVICE,
+        LogOperate.DELETE_THIRD_DEVICE,
+        LogOperate.CLEAR_THIRD_DEVICE,
+    },
+)
+
+# Records that are deliberately left as `other` because none of the four
+# buckets is honest about them. Listed rather than left implicit so the
+# coverage test can tell a considered omission from a forgotten record —
+# `record_type` still names each one exactly, which is what an automation
+# should match on.
+UNBUCKETED_RECORD_TYPES: frozenset[int] = frozenset(
+    {
+        # Storage is full; nothing opened or closed.
+        LogOperate.SPACE_INSUFFICIENT,
+        # The lock restarted.
+        LogOperate.DOOR_REBOOT,
+        # Opened without a credential the lock recognises. Neither a
+        # successful unlock nor a refused one, and guessing either way
+        # would misreport a security event.
+        LogOperate.ILLEGAL_UNLOCK,
+        # The door was left open / someone went out; no bolt operation.
+        LogOperate.DOOR_GO_OUT,
+        # A verification step of a two-factor flow, not the unlock that
+        # may or may not follow it.
+        LogOperate.DOUBLE_CHECK_THIRD_DEVICE_VERIFY,
     },
 )
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -38,7 +38,7 @@ async def test_entity_device_info_model_carries_protocol(
     hass, sample_virtual_key
 ) -> None:
     info = _entity(hass, sample_virtual_key).device_info
-    assert "protocol" in info["model"]
+    assert info["model"] == "Protocol 5.3"
 
 
 async def test_entity_falls_back_to_lock_name_when_alias_missing(

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -151,3 +151,66 @@ async def test_log_event_has_unique_id(
     reg_entry = registry.async_get(state.entity_id)
     assert reg_entry is not None
     assert reg_entry.unique_id == f"{sample_virtual_key.lockMac}_log"
+
+
+def test_every_record_type_is_deliberately_classified() -> None:
+    """A record the SDK knows about must not fall into `other` by accident.
+
+    The buckets plus the explicit opt-out have to account for the whole
+    enum, so a type added to the SDK later fails here until someone has
+    decided what it means rather than silently becoming `other`.
+    """
+    from ttlock_ble import LogOperate
+
+    from custom_components.ttlock_ble.event import (
+        LOCK_RECORD_TYPES,
+        PASSWORD_CHANGE_RECORD_TYPES,
+        UNBUCKETED_RECORD_TYPES,
+        UNLOCK_FAILED_RECORD_TYPES,
+        UNLOCK_RECORD_TYPES,
+    )
+
+    accounted = (
+        UNLOCK_RECORD_TYPES
+        | LOCK_RECORD_TYPES
+        | UNLOCK_FAILED_RECORD_TYPES
+        | PASSWORD_CHANGE_RECORD_TYPES
+        | UNBUCKETED_RECORD_TYPES
+    )
+    assert set(LogOperate) - accounted == set()
+
+
+def test_the_buckets_do_not_overlap() -> None:
+    """A record type means one thing; two buckets would make order decide."""
+    from custom_components.ttlock_ble.event import (
+        LOCK_RECORD_TYPES,
+        PASSWORD_CHANGE_RECORD_TYPES,
+        UNBUCKETED_RECORD_TYPES,
+        UNLOCK_FAILED_RECORD_TYPES,
+        UNLOCK_RECORD_TYPES,
+    )
+
+    buckets = [
+        UNLOCK_RECORD_TYPES,
+        LOCK_RECORD_TYPES,
+        UNLOCK_FAILED_RECORD_TYPES,
+        PASSWORD_CHANGE_RECORD_TYPES,
+        UNBUCKETED_RECORD_TYPES,
+    ]
+    for i, first in enumerate(buckets):
+        for second in buckets[i + 1 :]:
+            assert first & second == frozenset()
+
+
+def test_a_passcode_carrying_record_never_leaks_its_code() -> None:
+    """Newly classified types must not have widened what reaches an attribute."""
+    from ttlock_ble import LogOperate
+
+    from custom_components.ttlock_ble.event import (
+        PASSCODE_RECORD_TYPES,
+        UNLOCK_RECORD_TYPES,
+    )
+
+    assert LogOperate.ADMIN_CODE_UNLOCK in PASSCODE_RECORD_TYPES
+    assert LogOperate.DOUBLE_CHECK_PASSCODE_UNLOCK in PASSCODE_RECORD_TYPES
+    assert LogOperate.ADMIN_CODE_UNLOCK in UNLOCK_RECORD_TYPES


### PR DESCRIPTION
## Problem

The lock reports 81 kinds of operation record and only 31 were mapped to an event type. Half arrived as `other`, including plain unlocks and locks from face recognition, palm vein, QR code, third-party devices and two-factor flows, and every failure mode of a card or face read. An automation could still match on the exact `record_type` attribute, but the event type it was listening for said nothing about what happened.

## Changes

The buckets now account for every `LogOperate` the SDK knows:

| Bucket | Added |
|---|---|
| `unlock` | server, operate-key, door sensor, QR code, 3D face, app/gateway auth key, all `double_check_*`, palm vein, admin code, third device |
| `lock` | door sensor, operate-key, app dead lock, 3D face, palm vein, third device |
| `unlock_failed` | IC (plain and blacklist), QR code, 3D face (reverse and invalid time), CPU card, palm vein, card, third device |
| `password_change` | clear fingerprints, 3D face add/delete/clear, palm vein add/delete/clear, passcode added, third device add/delete/clear |

Records that no bucket describes honestly are listed in `UNBUCKETED_RECORD_TYPES` rather than left implicit — storage full, a reboot, a door left open, a two-factor verification step, and `illegal_unlock`, which is neither a successful unlock nor a refused one and would misreport a security event either way. They still carry their exact `record_type`.

`password_change` keeps its name although it now covers credentials of every kind: renaming an event type breaks every automation listening for it, and it already covered card and fingerprint enrolment before this change.

Also: the device model reads `Protocol 5.3` rather than `protocol 5.3`.

## Verification

`ruff format --check`, `ruff check`, `mypy` and the full suite pass at 100% coverage.

Two invariants are now tested: the union of the four buckets and the explicit opt-out covers the whole enum, and the buckets are disjoint. A record type added to the SDK later fails the suite until someone decides what it means, instead of quietly becoming `other`.

One thing this does **not** change, worth recording because it looks like a gap: an auto-lock produces no event, because the firmware writes no operation record for it. An explicit lock does — `operate_ble_lock`, already classified — which is why a lock driven from Home Assistant shows up and one that closed itself does not. The advertisement channel remains the only way to observe the latter.