### PR TITLE
feat(advertisement): read the bolt position while none is known

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Two details are load-bearing:
 - The decoded trailing address must equal the lock's MAC. A payload long enough to decode is not proof it is a TTLock payload, and that address is the only field whose value can be checked independently.
 - An advertisement that decodes reaches the entities via `async_set_updated_data`. Nothing here opens a session and nothing falls back to one.
 
-An advertisement we cannot decode, or one from a dormant lock, publishes nothing and asks for nothing. Until the lock is heard awake the entity reports `unknown`, which is what is actually known — the bolt position is not something anyone can state before the lock does.
+An advertisement we cannot decode, or one from a dormant lock, carries no bolt position. While none is known at all the coordinator reads one over BLE — being heard is proof the lock is in range, which is the one moment a connect is worth attempting — rate-limited by `STATE_PROBE_COOLDOWN_SECONDS` so a lock that keeps refusing is not connected to on every advertisement it sends, and disarmed the moment a position becomes known. Until the lock is heard awake the entity reports `unknown`, which is what is actually known — the bolt position is not something anyone can state before the lock does.
 
 The diagnostics dump carries the last advertisement per lock, raw bytes included, with `decoded: null` when the payload does not match the layout we know — that is what makes a "state never updates" report answerable without a round trip.
 

--- a/custom_components/ttlock_ble/advertisement.py
+++ b/custom_components/ttlock_ble/advertisement.py
@@ -40,12 +40,12 @@ class TtlockBleAdvertisementTracker:
     once the lock has dropped the connection it pushes events on, which
     it does within seconds of going idle.
 
-    Nothing here opens a session, and nothing falls back to one. A
-    dormant lock advertises without a usable bolt position, so those
+    A dormant lock advertises without a usable bolt position, so those
     frames carry only battery and the entity keeps reporting whatever
-    was last known — `unknown`, if the lock has not been awake since
-    Home Assistant started. That is the honest answer: the bolt position
-    is not something anyone knows until the lock says so.
+    was last known. While that is nothing at all — the lock has not been
+    awake since Home Assistant started — the coordinator is told the
+    lock was heard, and reads the position over BLE instead. Being heard
+    is what makes that worth attempting: it means the lock is in range.
     """
 
     def __init__(
@@ -82,6 +82,7 @@ class TtlockBleAdvertisementTracker:
         if advertisement is not None:
             self._coordinator.async_apply_advertisement(mac, advertisement)
             return
+        self._coordinator.async_note_lock_seen(mac)
         LOGGER.debug(
             "No state in the advertisement for %s (%s)",
             mac,

--- a/custom_components/ttlock_ble/coordinator.py
+++ b/custom_components/ttlock_ble/coordinator.py
@@ -50,6 +50,11 @@ LOCK_STATE_UNLOCKED = 1
 # busy for as long as the records stay unread.
 LOG_RETRY_COOLDOWN_SECONDS = 300.0
 
+# How long to leave a lock alone between attempts to read a bolt position
+# nothing has reported yet. Long enough that a lock which keeps refusing
+# is not connected to on every advertisement it sends.
+STATE_PROBE_COOLDOWN_SECONDS = 300.0
+
 
 class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinatorData"]):
     """Publish lock state, from advertisements and from on-demand reads."""
@@ -76,6 +81,7 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
         self._log_fetches: set[str] = set()
         self._records_pending: dict[str, bool] = {}
         self._log_retries: dict[str, CALLBACK_TYPE] = {}
+        self._state_probes: dict[str, CALLBACK_TYPE] = {}
 
     @property
     def connections(self) -> dict[str, TtlockBleConnection]:
@@ -132,6 +138,53 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
         }
         self.async_set_updated_data({**(self.data or {}), mac: snapshot})
         self._async_sync_operation_log(mac, advertisement)
+        self.async_note_lock_seen(mac)
+
+    @callback
+    def async_note_lock_seen(self, mac: str) -> None:
+        """
+        Read the bolt position over BLE while nothing has reported one.
+
+        An advertisement carries the bolt position only while the lock is
+        awake; a dormant one clears that bit along with the radio. A lock
+        that has not been awake since Home Assistant started therefore
+        has no position anyone can state, and nothing else will produce
+        one until someone touches the door.
+
+        Being heard at all is the useful signal here: it means the lock
+        is in range, which is the one moment a connect is worth trying.
+        The attempt is rate-limited because it is worth trying, not worth
+        repeating — a dormant lock takes several connects to answer, and
+        this must not turn every advertisement into one.
+        """
+        if self.async_has_state(mac):
+            self._async_cancel_state_probe(mac)
+            return
+        if mac not in self._connections or mac in self._state_probes:
+            return
+        self._state_probes[mac] = async_call_later(
+            self.hass,
+            STATE_PROBE_COOLDOWN_SECONDS,
+            partial(self._async_clear_state_probe, mac),
+        )
+        LOGGER.debug("No bolt position known for %s, reading it over BLE", mac)
+        self.config_entry.async_create_task(
+            self.hass,
+            self.async_request_refresh(),
+            name=f"{DOMAIN}.state_probe.{mac}",
+        )
+
+    @callback
+    def _async_clear_state_probe(self, mac: str, _now: datetime) -> None:
+        """Let the next advertisement try again."""
+        self._state_probes.pop(mac, None)
+
+    @callback
+    def _async_cancel_state_probe(self, mac: str) -> None:
+        """Drop the rate limit once the position is known."""
+        cancel = self._state_probes.pop(mac, None)
+        if cancel is not None:
+            cancel()
 
     @callback
     def _async_sync_operation_log(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -294,10 +294,11 @@ async def test_dormant_advertisement_still_reads_the_log(hass) -> None:
     """Anything done at the door is recorded, then the lock goes back to sleep."""
     conn = _mock_connection()
     coordinator = _log_coordinator(hass, conn)
-    coordinator.async_apply_advertisement(
-        MAC, _advertisement(unlocked=False, dormant=True, records=True)
-    )
-    await hass.async_block_till_done()
+    with patch.object(coordinator, "async_request_refresh"):
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, dormant=True, records=True)
+        )
+        await hass.async_block_till_done()
     conn.async_get_operation_log.assert_awaited_once()
 
 
@@ -370,3 +371,103 @@ async def test_the_retry_stops_once_the_flag_clears(hass) -> None:
     )
     await hass.async_block_till_done()
     assert conn.async_get_operation_log.await_count == 1
+
+
+async def test_a_dormant_sighting_reads_the_bolt_position_when_unknown(hass) -> None:
+    """A dormant frame has no position, but proves the lock is in range."""
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    with patch.object(coordinator, "async_request_refresh") as refresh:
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, dormant=True)
+        )
+        await hass.async_block_till_done()
+    refresh.assert_called_once()
+
+
+async def test_an_awake_sighting_reads_nothing(hass) -> None:
+    """The advertisement already carried the position; there is nothing to ask."""
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    with patch.object(coordinator, "async_request_refresh") as refresh:
+        coordinator.async_apply_advertisement(MAC, _advertisement(unlocked=False))
+        await hass.async_block_till_done()
+    refresh.assert_not_called()
+
+
+async def test_the_read_is_not_repeated_on_every_advertisement(hass) -> None:
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    with patch.object(coordinator, "async_request_refresh") as refresh:
+        for _ in range(3):
+            coordinator.async_apply_advertisement(
+                MAC, _advertisement(unlocked=False, dormant=True)
+            )
+            await hass.async_block_till_done()
+    refresh.assert_called_once()
+
+
+async def test_the_read_is_tried_again_after_the_cooldown(hass) -> None:
+    from datetime import timedelta
+
+    from homeassistant.util import dt as dt_util
+    from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+    from custom_components.ttlock_ble.coordinator import STATE_PROBE_COOLDOWN_SECONDS
+
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    with patch.object(coordinator, "async_request_refresh") as refresh:
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, dormant=True)
+        )
+        await hass.async_block_till_done()
+        async_fire_time_changed(
+            hass,
+            dt_util.utcnow() + timedelta(seconds=STATE_PROBE_COOLDOWN_SECONDS + 1),
+        )
+        await hass.async_block_till_done()
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, dormant=True)
+        )
+        await hass.async_block_till_done()
+    assert refresh.call_count == 2
+
+
+async def test_a_known_position_stops_the_reads(hass) -> None:
+    """Once the lock has been heard awake there is nothing left to ask about."""
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    coordinator.async_apply_advertisement(MAC, _advertisement(unlocked=True))
+    await hass.async_block_till_done()
+    with patch.object(coordinator, "async_request_refresh") as refresh:
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, dormant=True)
+        )
+        await hass.async_block_till_done()
+    refresh.assert_not_called()
+
+
+async def test_a_sighting_of_an_unknown_lock_reads_nothing(hass) -> None:
+    coordinator = _coordinator(hass, {})
+    coordinator.config_entry = _task_entry(hass)
+    with patch.object(coordinator, "async_request_refresh") as refresh:
+        coordinator.async_note_lock_seen("11:22:33:44:55:66")
+        await hass.async_block_till_done()
+    refresh.assert_not_called()
+
+
+async def test_learning_the_position_disarms_the_pending_read(hass) -> None:
+    """The rate limit exists to space retries, not to outlive their reason."""
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    with patch.object(coordinator, "async_request_refresh"):
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, dormant=True)
+        )
+        await hass.async_block_till_done()
+    assert MAC in coordinator._state_probes
+
+    coordinator.async_apply_advertisement(MAC, _advertisement(unlocked=True))
+    await hass.async_block_till_done()
+    assert MAC not in coordinator._state_probes

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -53,7 +53,7 @@ async def test_setup_registers_bluetooth_callback_per_lock(
     assert len(setup_integration.runtime_data.bluetooth_unsubs) == 1
 
 
-async def test_an_undecodable_advertisement_does_not_poll(
+async def test_an_undecodable_advertisement_reads_the_unknown_position(
     hass,
     sample_stored_key,
     enable_bluetooth,
@@ -61,7 +61,7 @@ async def test_an_undecodable_advertisement_does_not_poll(
     mock_cloud,
     mock_ttlock_connection,
 ) -> None:
-    """Nothing about an advertisement we cannot read justifies a BLE session."""
+    """Being heard is proof the lock is in range, which is when a read is worth it."""
     from unittest.mock import MagicMock, patch
 
     from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -94,7 +94,7 @@ async def test_an_undecodable_advertisement_does_not_poll(
     ) as mocked_refresh:
         captured_callbacks[0](service_info, MagicMock())
         await hass.async_block_till_done()
-        mocked_refresh.assert_not_called()
+        mocked_refresh.assert_called_once()
 
 
 async def test_unload_invokes_bluetooth_unsubs(


### PR DESCRIPTION
## Problem

An advertisement carries the bolt position only while the lock is awake; a dormant one clears that bit along with the radio. A lock that has not been awake since Home Assistant started therefore has no position anyone can state, and nothing produces one until someone touches the door — which on an idle lock can be hours.

## Change

An advertisement that carries no position — dormant, or one that does not decode — now asks for one over BLE, but only while none is known.

Being heard at all is what makes that worth doing: it means the lock is in range, which is the one moment a connect is worth attempting. It is not a timer and not a poll; nothing happens unless the lock has just been heard and the position is still unknown.

Rate-limited by `STATE_PROBE_COOLDOWN_SECONDS`, because it is worth trying and not worth repeating: a dormant lock takes several connects to answer, and without the limit every advertisement it sent would become one. The limit is dropped the moment a position becomes known, so it never outlives its reason.

## Verification

`ruff format --check`, `ruff check`, `mypy` and the full suite pass at 100% coverage.

Measured on a live instance, starting from the exact case this addresses — a dormant lock with no position known:

```
14:48:12  deployed; entity unknown
14:48:28  connection up      <- an advertisement with no position asked for one
14:48:28  entity -> locked   <- position learned, 16s after startup
14:48:31  connection down    <- one session, 3.6s
14:48:31 → 14:50:47          <- no further attempts
```

One short session, and no repeat once the position was known. Before this the entity stayed `unknown` until something happened at the door.