### PR TITLE
feat(switch): expose the lock's beep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ binary_sensor.py → connectivity BinarySensorEntity reflecting live BLE link st
                     (named "Bluetooth connection": a healthy idle lock holds
                     no session, so this being off says nothing about reach)
 event.py         → EventEntity that surfaces decoded LogEntry records
+switch.py        → the lock's beep; assumed state, admin keys only
 record_store.py  → persists the operation-log cursor per lock, so a
                     restart resumes instead of re-seeding
 ```
@@ -165,6 +166,10 @@ The diagnostics dump carries the last advertisement per lock, raw bytes included
 ### Event entity
 
 `event.py` republishes decoded `LogEntry` records. Every `LogOperate` the SDK knows is accounted for: the four buckets plus `UNBUCKETED_RECORD_TYPES`, an explicit list of records no bucket describes honestly (storage full, reboot, `illegal_unlock`, door left open, a two-factor verification step). A test asserts the union covers the enum, so a record type added to the SDK later fails the suite instead of quietly becoming `other`. Note that an auto-lock produces no record at all — the firmware writes none — which is why the advertisement channel is the only way to see one. The SDK carries keypad codes, card numbers, fingerprint ids and fob MACs in one `password` field; only the first are secret, so `PASSCODE_RECORD_TYPES` lists the record types whose value is a working door code and those never reach an event attribute. An attribute lands in the recorder database and is readable through the API by any user, admin or not.
+
+### Sound switch
+
+`switch.py` toggles the lock's keypad/lock beep. Two constraints shape it. It is `assumed_state`, because the firmware has no opcode reporting the setting back — neither a query nor the advertisement carries it — so the entity shows the last value it sent, which stops being true the moment the official app changes it; HA renders that as two buttons rather than one toggle, which is the honest presentation. And it is only created for a key that is both `is_admin()` and carries an `adminPs`: the firmware gates the command behind CHECK_ADMIN, and a manual-key entry usually has neither, where the entity could only ever fail.
 
 ### Diagnostics
 

--- a/custom_components/ttlock_ble/__init__.py
+++ b/custom_components/ttlock_ble/__init__.py
@@ -39,6 +39,7 @@ PLATFORMS: list[Platform] = [
     Platform.EVENT,
     Platform.LOCK,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 

--- a/custom_components/ttlock_ble/connection.py
+++ b/custom_components/ttlock_ble/connection.py
@@ -165,6 +165,10 @@ class TtlockBleConnection:
         """Send an UNLOCK command on the live connection (raises on failure)."""
         await self._async_run_command("unlock")
 
+    async def async_set_lock_sound(self, *, enabled: bool) -> None:
+        """Turn the lock's beep on or off (raises on failure)."""
+        await self._async_run_command("sound_on" if enabled else "sound_off")
+
     async def async_get_operation_log(self) -> list[LogEntry]:
         """
         Fetch operation records from the lock and dispatch the new ones.
@@ -246,7 +250,7 @@ class TtlockBleConnection:
 
     async def _async_run_command(self, action: str) -> None:
         """
-        Acquire the lock, ensure connected, then call `lock`/`unlock`.
+        Acquire the lock, ensure connected, then run one command on it.
 
         Everything that is not already a `TTLockError` is converted into
         one so callers only ever see the integration's own exception
@@ -265,8 +269,10 @@ class TtlockBleConnection:
             try:
                 if action == "lock":
                     await client.lock()
-                else:
+                elif action == "unlock":
                     await client.unlock()
+                else:
+                    await client.set_lock_sound(enabled=action == "sound_on")
             except TTLockError:
                 await self._async_disconnect_locked()
                 raise

--- a/custom_components/ttlock_ble/manifest.json
+++ b/custom_components/ttlock_ble/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/roquerodrigo/ha-ttlock-ble/issues",
   "requirements": [
-    "ttlock-ble==0.2.0"
+    "ttlock-ble==0.2.1"
   ],
   "version": "3.6.1"
 }

--- a/custom_components/ttlock_ble/switch.py
+++ b/custom_components/ttlock_ble/switch.py
@@ -1,0 +1,108 @@
+"""Switch platform for ttlock_ble — the lock's beep."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import EntityCategory
+from homeassistant.exceptions import HomeAssistantError
+
+from ttlock_ble import TTLockError
+
+from .const import LOGGER
+from .entity import TtlockBleEntity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from ttlock_ble import VirtualKey
+
+    from .connection import TtlockBleConnection
+    from .coordinator import TtlockBleDataUpdateCoordinator
+    from .data import TtlockBleConfigEntry
+
+
+def _can_manage_sound(key: VirtualKey) -> bool:
+    """
+    Report whether this key may change lock settings at all.
+
+    The firmware gates the command behind CHECK_ADMIN, which needs both
+    an admin key and the admin passcode that authorises it. A key
+    obtained outside a TTLock account often carries no passcode, and an
+    entity that can only ever fail is worse than no entity.
+    """
+    return key.is_admin() and bool(key.adminPs)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: TtlockBleConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Create one sound switch per lock this key may administer."""
+    data = entry.runtime_data
+    async_add_entities(
+        TtlockBleSoundSwitch(data.coordinator, key, data.connections[key.lockMac])
+        for key in data.virtual_keys
+        if _can_manage_sound(key)
+    )
+
+
+class TtlockBleSoundSwitch(TtlockBleEntity, SwitchEntity):
+    """
+    The lock's keypad/lock beep.
+
+    `assumed_state` because the firmware has no opcode that reports this
+    setting back: neither a query nor the advertisement carries it. What
+    the entity shows is the last value it sent, which stops being true
+    the moment someone changes it from the official app — and is unknown
+    entirely until something sets it. Home Assistant renders an assumed
+    state as two buttons rather than one toggle, which is the honest
+    presentation: the command can be sent, the answer cannot be read.
+    """
+
+    _attr_translation_key = "sound"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_assumed_state = True
+    _attr_icon = "mdi:volume-high"
+
+    def __init__(
+        self,
+        coordinator: TtlockBleDataUpdateCoordinator,
+        key: VirtualKey,
+        connection: TtlockBleConnection,
+    ) -> None:
+        """Bind the switch to its key + connection."""
+        super().__init__(coordinator, key)
+        self._connection = connection
+        self._attr_is_on: bool | None = None
+
+    @property
+    def unique_id(self) -> str:
+        """Return a stable unique id for this entity."""
+        return f"{self._key.lockMac}_sound"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:  # noqa: ARG002
+        """Turn the beep on."""
+        await self._async_set(enabled=True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:  # noqa: ARG002
+        """Turn the beep off."""
+        await self._async_set(enabled=False)
+
+    async def _async_set(self, *, enabled: bool) -> None:
+        """Send the command and adopt what was sent, since nothing reads it back."""
+        try:
+            await self._connection.async_set_lock_sound(enabled=enabled)
+        except TTLockError as exc:
+            LOGGER.warning(
+                "Failed to set the sound of %s: %s",
+                self._key.lockMac,
+                exc,
+            )
+            msg = f"Failed to set the sound of {self._key.lockMac}: {exc}"
+            raise HomeAssistantError(msg) from exc
+        self._attr_is_on = enabled
+        self.async_write_ha_state()

--- a/custom_components/ttlock_ble/translations/en.json
+++ b/custom_components/ttlock_ble/translations/en.json
@@ -140,6 +140,11 @@
       "last_seen": {
         "name": "Last seen"
       }
+    },
+    "switch": {
+      "sound": {
+        "name": "Sound"
+      }
     }
   }
 }

--- a/custom_components/ttlock_ble/translations/pt-BR.json
+++ b/custom_components/ttlock_ble/translations/pt-BR.json
@@ -140,6 +140,11 @@
       "last_seen": {
         "name": "Visto por último"
       }
+    },
+    "switch": {
+      "sound": {
+        "name": "Som"
+      }
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
     "pytest-cov==7.1.0",
     "pytest-homeassistant-custom-component==0.13.354",
     "serialx==1.8.2",
-    "ttlock-ble==0.2.0",
+    "ttlock-ble==0.2.1",
 ]
 lint = [
     "ruff==0.16.4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,7 @@ def mock_ttlock_client() -> Generator[MagicMock]:
     instance.get_operation_log = AsyncMock(return_value=[])
     instance.lock = AsyncMock(return_value=None)
     instance.unlock = AsyncMock(return_value=None)
+    instance.set_lock_sound = AsyncMock(return_value=None)
     instance.add_event_listener = MagicMock(return_value=None)
     instance.remove_event_listener = MagicMock(return_value=None)
     with patch("custom_components.ttlock_ble.connection.TTLockClient") as cls:
@@ -160,6 +161,7 @@ def mock_ttlock_connection() -> Generator[MagicMock]:
     instance.async_get_operation_log = AsyncMock(return_value=[])
     instance.async_lock = AsyncMock(return_value=None)
     instance.async_unlock = AsyncMock(return_value=None)
+    instance.async_set_lock_sound = AsyncMock(return_value=None)
     instance.is_connected = True
     with patch("custom_components.ttlock_ble.TtlockBleConnection") as cls:
         cls.return_value = instance

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -692,3 +692,33 @@ async def test_the_cursor_is_not_reported_when_nothing_is_new(
     )
     await conn.async_get_operation_log()
     assert remembered == []
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+async def test_set_lock_sound_reaches_the_lock(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+    enabled,
+) -> None:
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    await conn.async_set_lock_sound(enabled=enabled)
+    mock_ttlock_client.set_lock_sound.assert_awaited_once_with(enabled=enabled)
+
+
+async def test_set_lock_sound_raises_when_out_of_range(
+    hass,
+    sample_virtual_key,
+    mock_ttlock_client,
+) -> None:
+    """The caller has to learn the setting did not change."""
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    with (
+        patch(
+            "custom_components.ttlock_ble.connection.async_ble_device_from_address",
+            return_value=None,
+        ),
+        pytest.raises(TTLockError),
+    ):
+        await conn.async_set_lock_sound(enabled=True)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+from ttlock_ble import TTLockError
+
+
+def _switch_state(hass):
+    return hass.states.async_all("switch")[0]
+
+
+async def test_sound_switch_created_for_an_admin_key(hass, setup_integration) -> None:
+    assert len(hass.states.async_all("switch")) == 1
+
+
+async def test_sound_switch_starts_without_a_value(hass, setup_integration) -> None:
+    """Nothing reads the setting back, so nothing is known until something sets it."""
+    assert _switch_state(hass).state == "unknown"
+
+
+async def test_sound_switch_is_assumed(hass, setup_integration) -> None:
+    """The command can be sent; the answer cannot be read."""
+    assert _switch_state(hass).attributes["assumed_state"] is True
+
+
+async def test_sound_switch_has_unique_id(
+    hass, setup_integration, sample_virtual_key
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    entry = er.async_get(hass).async_get(_switch_state(hass).entity_id)
+    assert entry is not None
+    assert entry.unique_id == f"{sample_virtual_key.lockMac}_sound"
+
+
+@pytest.mark.parametrize(
+    ("service", "expected"),
+    [("turn_on", True), ("turn_off", False)],
+)
+async def test_sound_switch_sends_the_command(
+    hass,
+    setup_integration,
+    mock_ttlock_connection,
+    service,
+    expected,
+) -> None:
+    state = _switch_state(hass)
+    await hass.services.async_call(
+        "switch",
+        service,
+        {"entity_id": state.entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    mock_ttlock_connection.async_set_lock_sound.assert_awaited_with(enabled=expected)
+    assert hass.states.get(state.entity_id).state == ("on" if expected else "off")
+
+
+async def test_a_refused_command_surfaces_and_keeps_the_old_value(
+    hass,
+    setup_integration,
+    mock_ttlock_connection,
+) -> None:
+    """A failed write must not leave the entity claiming it took effect."""
+    state = _switch_state(hass)
+    await hass.services.async_call(
+        "switch", "turn_on", {"entity_id": state.entity_id}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    mock_ttlock_connection.async_set_lock_sound = AsyncMock(
+        side_effect=TTLockError("lock refused"),
+    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "switch", "turn_off", {"entity_id": state.entity_id}, blocking=True
+        )
+    assert hass.states.get(state.entity_id).state == "on"
+
+
+async def test_no_switch_without_the_admin_passcode(
+    hass,
+    sample_stored_key,
+    enable_bluetooth,
+    enable_custom_integrations,
+    mock_cloud,
+    mock_ttlock_connection,
+) -> None:
+    """CHECK_ADMIN needs it; an entity that can only ever fail is worse than none."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.ttlock_ble.const import DOMAIN
+
+    key = dict(sample_stored_key)
+    key["adminPs"] = ""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "u", "password": "p", "keys": [key]},
+        unique_id="u",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.states.async_all("switch") == []
+
+
+async def test_no_switch_for_a_non_admin_key(
+    hass,
+    sample_stored_key,
+    enable_bluetooth,
+    enable_custom_integrations,
+    mock_cloud,
+    mock_ttlock_connection,
+) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.ttlock_ble.const import DOMAIN
+
+    key = dict(sample_stored_key)
+    key["userType"] = "110302"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "u", "password": "p", "keys": [key]},
+        unique_id="u",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.states.async_all("switch") == []


### PR DESCRIPTION
Consumes `set_lock_sound`, added to the SDK in `roquerodrigo/ttlock-ble#68` (originally contributed by @dariusz-rudzinski) and released as `ttlock-ble` 0.2.1, which this bumps the pin to.

## The entity

A switch for the keypad/lock beep. Two properties of the command shape it.

**`assumed_state`.** The firmware has no opcode reporting this setting back — neither a query nor the advertisement carries it — so the switch shows the last value it sent. That stops being true the moment the official app changes it, and is unknown entirely until something sets it. Home Assistant renders an assumed state as two buttons rather than one toggle, which is what the lock actually offers: the command can be sent, the answer cannot be read.

**Admin keys only.** The firmware gates the command behind CHECK_ADMIN, which needs both an admin key and the admin passcode authorising it. A key obtained outside a TTLock account usually carries neither, so the entity is created only when both are present — one that could only ever fail is worse than none.

A refused command raises instead of adopting the value, so the switch never reports a setting the lock rejected.

## Verification

`ruff format --check`, `ruff check`, `mypy` and the full suite pass at 100% coverage.

Exercised against a physical lock, in both directions, before and after the SDK release:

```
set_lock_sound response: cmd_echo=0x62 status=1 data=4b02   -> off
set_lock_sound response: cmd_echo=0x62 status=1 data=4b02   -> on
```

The admin handshake answers `status=1` and the command is accepted only after it, so the gate is real firmware behaviour rather than an app-side convention. Two seconds from connect to acknowledgement. Re-checked on the published 0.2.1 build afterwards: the switch reports `on` with `assumed_state: true`.