### PR TITLE
feat(device): show the model, hardware and firmware the lock reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,10 @@ event.py         → EventEntity that surfaces decoded LogEntry records
 switch.py        → the lock's beep; assumed state, admin keys only
 record_store.py  → persists the operation-log cursor per lock, so a
                     restart resumes instead of re-seeding
+device_description_store.py
+                 → persists what each lock reported about itself (model,
+                    hardware, firmware), so a restart shows it before any
+                    session is opened
 ```
 
 ### Entry typing
@@ -152,6 +156,14 @@ Two details are load-bearing:
 An advertisement we cannot decode, or one from a dormant lock, carries no bolt position. While none is known at all the coordinator reads one over BLE — being heard is proof the lock is in range, which is the one moment a connect is worth attempting — rate-limited by `STATE_PROBE_COOLDOWN_SECONDS` so a lock that keeps refusing is not connected to on every advertisement it sends, and disarmed the moment a position becomes known. Until the lock is heard awake the entity reports `unknown`, which is what is actually known — the bolt position is not something anyone can state before the lock does.
 
 The diagnostics dump carries the last advertisement per lock, raw bytes included, with `decoded: null` when the payload does not match the layout we know — that is what makes a "state never updates" report answerable without a round trip.
+
+### Device description
+
+`device_description_store.py` keeps, per MAC, the model, hardware and firmware strings the lock answers over the standard BLE Device Information Service (`get_device_info()` in the SDK). Three things shape it:
+
+- **Nothing connects for them.** The read rides on a poll that just reached the lock, in `coordinator.py`'s `_async_describe`. A lock only grants a session while it is awake, and hardware strings are not worth waking one for.
+- **Once per Home Assistant run, not once ever.** The values are static until a firmware upgrade changes them, so the store is what a restart displays, and the first successful poll of each run re-reads and replaces it.
+- **The registry device is updated in place.** An entity's `device_info` is only read when the entity is registered, so a description learned mid-run would otherwise wait for the next restart to appear. A field the lock did not answer is left untouched rather than blanked — `entity.py` falls back to the key's protocol version for the model, which beats an empty one.
 
 ### Lock entity
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ custom_components/ttlock_ble/
 ├── const.py           # DOMAIN, LOGGER, defaults
 ├── coordinator.py     # DataUpdateCoordinator polling each connection
 ├── data/              # one TypedDict/dataclass per file + type aliases in __init__.py
+├── device_description_store.py  # per-lock model / hardware / firmware, persisted
 ├── diagnostics.py     # redacted credentials/keys
 ├── entity.py          # base CoordinatorEntity with DeviceInfo
 ├── event.py           # TtlockBleLogEvent: operation-log records as HA events

--- a/custom_components/ttlock_ble/__init__.py
+++ b/custom_components/ttlock_ble/__init__.py
@@ -22,6 +22,7 @@ from .connection import TtlockBleConnection
 from .const import CONF_PERMANENT_CONNECTION, DOMAIN, LOGGER
 from .coordinator import TtlockBleDataUpdateCoordinator
 from .data import TtlockBleData, TtlockBleLogCursor
+from .device_description_store import TtlockBleDeviceDescriptionStore
 from .record_store import TtlockBleRecordStore
 
 if TYPE_CHECKING:
@@ -122,7 +123,13 @@ async def async_setup_entry(
         for connection in connections.values():
             await connection.async_start()
 
-    coordinator = TtlockBleDataUpdateCoordinator(hass=hass, connections=connections)
+    description_store = TtlockBleDeviceDescriptionStore(hass)
+    await description_store.async_load()
+    coordinator = TtlockBleDataUpdateCoordinator(
+        hass=hass,
+        connections=connections,
+        descriptions=description_store,
+    )
 
     bluetooth_unsubs = TtlockBleAdvertisementTracker(hass, coordinator).async_register(
         virtual_keys,

--- a/custom_components/ttlock_ble/connection.py
+++ b/custom_components/ttlock_ble/connection.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from bleak import BleakClient
     from homeassistant.core import HomeAssistant
 
-    from ttlock_ble import LockEvent, LockState, LogEntry, VirtualKey
+    from ttlock_ble import DeviceInfo, LockEvent, LockState, LogEntry, VirtualKey
 
 
 RECONNECT_INITIAL_BACKOFF = 1.0
@@ -155,6 +155,34 @@ class TtlockBleConnection:
                     exc,
                 )
                 await self._async_disconnect_locked()
+                return None
+
+    async def async_get_device_info(self) -> DeviceInfo | None:
+        """
+        Read the lock's Device Information Service through the connection.
+
+        Returns `None` when the lock is out of range or the read failed.
+        These are plain Bluetooth SIG characteristics rather than the
+        lock's own protocol, so nothing here is encrypted and no
+        handshake is involved - but they still need a session, and the
+        lock only grants one while it is awake.
+        """
+        async with self._lock:
+            client = await self._async_ensure_connected_locked()
+            if client is None:
+                return None
+            try:
+                return await client.get_device_info()
+            except Exception as exc:  # noqa: BLE001
+                # The SDK reports an unreadable characteristic as `None`
+                # rather than raising, so anything arriving here broke
+                # the link itself. Hardware strings are not worth losing
+                # a poll over: the caller keeps whatever it knew.
+                LOGGER.debug(
+                    "get_device_info failed for %s: %s",
+                    self._key.lockMac,
+                    exc,
+                )
                 return None
 
     async def async_lock(self) -> None:

--- a/custom_components/ttlock_ble/coordinator.py
+++ b/custom_components/ttlock_ble/coordinator.py
@@ -19,7 +19,12 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import (
+    async_get as async_get_device_registry,
+)
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from ttlock_ble import LockState
@@ -37,8 +42,10 @@ if TYPE_CHECKING:
     from .data import (
         TtlockBleConfigEntry,
         TtlockBleCoordinatorData,
+        TtlockBleDeviceDescription,
         TtlockBleLockState,
     )
+    from .device_description_store import TtlockBleDeviceDescriptionStore
 
 
 LOCK_STATE_LOCKED = 0
@@ -65,6 +72,7 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
         self,
         hass: HomeAssistant,
         connections: dict[str, TtlockBleConnection],
+        descriptions: TtlockBleDeviceDescriptionStore,
     ) -> None:
         """
         Pin the per-MAC connection map. No polling interval on purpose.
@@ -78,6 +86,8 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
         """
         super().__init__(hass=hass, logger=LOGGER, name=DOMAIN)
         self._connections = connections
+        self._descriptions = descriptions
+        self._described: set[str] = set()
         self._log_fetches: set[str] = set()
         self._records_pending: dict[str, bool] = {}
         self._log_retries: dict[str, CALLBACK_TYPE] = {}
@@ -87,6 +97,11 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
     def connections(self) -> dict[str, TtlockBleConnection]:
         """Return the per-MAC connection map this coordinator polls."""
         return self._connections
+
+    @callback
+    def async_device_description(self, mac: str) -> TtlockBleDeviceDescription | None:
+        """Return the hardware strings `mac` last reported about itself."""
+        return self._descriptions.get(mac)
 
     @callback
     def async_has_state(self, mac: str) -> bool:
@@ -340,10 +355,67 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
                 connection.key.lockMac,
                 exc_info=True,
             )
+        await self._async_describe(connection)
         return {
             "locked": _parse_lock_state(raw_state),
             "battery_level": battery,
         }
+
+    async def _async_describe(self, connection: TtlockBleConnection) -> None:
+        """
+        Read the lock's hardware strings once per run, on an open session.
+
+        Model, hardware and firmware are static, and each costs a BLE
+        round trip, so this rides on a poll that just reached the lock
+        instead of connecting for them. Once per Home Assistant run
+        rather than once ever: a firmware upgrade changes what the lock
+        answers, and a value stored forever would outlive the truth.
+        """
+        mac = connection.key.lockMac
+        if mac in self._described:
+            return
+        info = await connection.async_get_device_info()
+        if info is None:
+            return
+        self._described.add(mac)
+        description: TtlockBleDeviceDescription = {
+            "model": info.model,
+            "hardware_version": info.hardware_revision,
+            "firmware_version": info.firmware_revision,
+        }
+        if description == self._descriptions.get(mac):
+            return
+        self._descriptions.async_remember(mac, description)
+        self._async_apply_description(mac, description)
+
+    @callback
+    def _async_apply_description(
+        self,
+        mac: str,
+        description: TtlockBleDeviceDescription,
+    ) -> None:
+        """
+        Stamp the hardware strings onto the registry device for `mac`.
+
+        The entity's `device_info` is only read when the entity is
+        registered, so a description learned mid-run would otherwise
+        wait for the next restart to show up. A field the lock did not
+        answer is left untouched rather than blanked - the protocol
+        version the entity falls back to is worth more than an empty
+        model.
+        """
+        device_registry = async_get_device_registry(self.hass)
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, format_mac(mac))},
+        )
+        if device is None:
+            return
+        device_registry.async_update_device(
+            device.id,
+            model=description["model"] or UNDEFINED,
+            hw_version=description["hardware_version"] or UNDEFINED,
+            sw_version=description["firmware_version"] or UNDEFINED,
+        )
 
 
 def _parse_lock_state(raw: int | None) -> bool | None:

--- a/custom_components/ttlock_ble/data/__init__.py
+++ b/custom_components/ttlock_ble/data/__init__.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from .config_data import TtlockBleConfigData
 from .credentials_input import TtlockBleCredentialsInput
+from .device_description import TtlockBleDeviceDescription
 from .diagnostics_advertisement import TtlockBleDiagnosticsAdvertisement
 from .diagnostics_entry import TtlockBleDiagnosticsEntry
 from .diagnostics_lock_summary import TtlockBleDiagnosticsLockSummary
@@ -40,6 +41,7 @@ __all__ = [
     "TtlockBleCoordinatorData",
     "TtlockBleCredentialsInput",
     "TtlockBleData",
+    "TtlockBleDeviceDescription",
     "TtlockBleDiagnosticsAdvertisement",
     "TtlockBleDiagnosticsEntry",
     "TtlockBleDiagnosticsLockSummary",

--- a/custom_components/ttlock_ble/data/device_description.py
+++ b/custom_components/ttlock_ble/data/device_description.py
@@ -1,0 +1,19 @@
+"""Hardware strings a lock reports over the BLE Device Information Service."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class TtlockBleDeviceDescription(TypedDict):
+    """
+    Hardware strings a lock reports over the Device Information Service.
+
+    Every value is `str | None`: the service is standard Bluetooth SIG,
+    but which characteristics a lock exposes is up to its firmware, and
+    the ones it does not answer are absent rather than empty.
+    """
+
+    model: str | None
+    hardware_version: str | None
+    firmware_version: str | None

--- a/custom_components/ttlock_ble/data/diagnostics_payload.py
+++ b/custom_components/ttlock_ble/data/diagnostics_payload.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, TypedDict
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from .device_description import TtlockBleDeviceDescription
     from .diagnostics_advertisement import TtlockBleDiagnosticsAdvertisement
     from .diagnostics_entry import TtlockBleDiagnosticsEntry
     from .diagnostics_lock_summary import TtlockBleDiagnosticsLockSummary
@@ -20,3 +21,4 @@ class TtlockBleDiagnosticsPayload(TypedDict):
     locks: list[TtlockBleDiagnosticsLockSummary]
     coordinator_state: Mapping[str, TtlockBleLockState]
     advertisements: Mapping[str, TtlockBleDiagnosticsAdvertisement | None]
+    device_descriptions: Mapping[str, TtlockBleDeviceDescription | None]

--- a/custom_components/ttlock_ble/device_description_store.py
+++ b/custom_components/ttlock_ble/device_description_store.py
@@ -1,0 +1,63 @@
+"""Persisted per-lock hardware description for ttlock_ble."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .data import TtlockBleDeviceDescription
+
+STORAGE_VERSION = 1
+STORAGE_KEY = f"{DOMAIN}.device_descriptions"
+SAVE_DELAY_SECONDS = 10
+
+
+class TtlockBleDeviceDescriptionStore:
+    """
+    Remember the hardware strings each lock has reported.
+
+    Reading them costs a BLE session, and a lock only grants one while it
+    is awake, so the answer is kept rather than asked for again on every
+    start: a restarted Home Assistant shows the model and the firmware
+    version of a lock nobody has touched in days, which is exactly when
+    a user goes looking for them.
+
+    Keyed by MAC rather than by entry, so a lock keeps its description
+    across a reconfigure, and for the same reason a cloud entry and a
+    manual entry describing the same lock agree.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Bind the descriptions to HA's storage helper."""
+        self._store: Store[dict[str, TtlockBleDeviceDescription]] = Store(
+            hass,
+            STORAGE_VERSION,
+            STORAGE_KEY,
+        )
+        self._descriptions: dict[str, TtlockBleDeviceDescription] = {}
+
+    async def async_load(self) -> None:
+        """Read the persisted descriptions, tolerating a missing or empty file."""
+        data = await self._store.async_load()
+        if not data:
+            return
+        self._descriptions = dict(data)
+
+    def get(self, mac: str) -> TtlockBleDeviceDescription | None:
+        """Return what `mac` last reported about itself, if anything."""
+        return self._descriptions.get(mac)
+
+    def async_remember(self, mac: str, description: TtlockBleDeviceDescription) -> None:
+        """Persist what `mac` reported, replacing any earlier answer."""
+        self._descriptions[mac] = description
+        self._store.async_delay_save(self._snapshot, SAVE_DELAY_SECONDS)
+
+    def _snapshot(self) -> dict[str, TtlockBleDeviceDescription]:
+        """Render the in-memory descriptions as the JSON the store writes."""
+        return dict(self._descriptions)

--- a/custom_components/ttlock_ble/diagnostics.py
+++ b/custom_components/ttlock_ble/diagnostics.py
@@ -60,13 +60,18 @@ async def async_get_config_entry_diagnostics(
     locks: list[TtlockBleDiagnosticsLockSummary] = [
         _summarize_key(key) for key in entry.runtime_data.keys
     ]
-    coordinator_state = entry.runtime_data.coordinator.data or {}
+    coordinator = entry.runtime_data.coordinator
+    coordinator_state = coordinator.data or {}
     return {
         "entry": diag_entry,
         "locks": locks,
         "coordinator_state": dict(coordinator_state),
         "advertisements": {
             key["lockMac"]: _summarize_advertisement(hass, key["lockMac"])
+            for key in entry.runtime_data.keys
+        },
+        "device_descriptions": {
+            key["lockMac"]: coordinator.async_device_description(key["lockMac"])
             for key in entry.runtime_data.keys
         },
     }

--- a/custom_components/ttlock_ble/entity.py
+++ b/custom_components/ttlock_ble/entity.py
@@ -37,15 +37,33 @@ class TtlockBleEntity(CoordinatorEntity[TtlockBleDataUpdateCoordinator]):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """One Home Assistant device per physical lock, keyed by MAC."""
+        """
+        One Home Assistant device per physical lock, keyed by MAC.
+
+        Model, hardware and firmware come from what the lock itself
+        reported the last time one was read off it. Until then the model
+        falls back to the protocol version carried by the key, which is
+        the only thing known about a lock nobody has connected to yet.
+        """
         mac = format_mac(self._key.lockMac)
+        description = self.coordinator.async_device_description(self._key.lockMac)
+        model = None if description is None else description["model"]
         return DeviceInfo(
             identifiers={(DOMAIN, mac)},
             connections={(CONNECTION_BLUETOOTH, mac)},
             name=self._key.lockAlias or self._key.lockName or self._key.lockMac,
             manufacturer=MANUFACTURER,
-            model=f"Protocol {self._key.lockVersion.protocolType}."
-            f"{self._key.lockVersion.protocolVersion}",
+            model=model or self._protocol_model,
+            hw_version=None if description is None else description["hardware_version"],
+            sw_version=None if description is None else description["firmware_version"],
+        )
+
+    @property
+    def _protocol_model(self) -> str:
+        """Return the protocol version the key carries, as a model string."""
+        return (
+            f"Protocol {self._key.lockVersion.protocolType}."
+            f"{self._key.lockVersion.protocolVersion}"
         )
 
     @property

--- a/custom_components/ttlock_ble/manifest.json
+++ b/custom_components/ttlock_ble/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/roquerodrigo/ha-ttlock-ble/issues",
   "requirements": [
-    "ttlock-ble==0.2.1"
+    "ttlock-ble==0.2.2"
   ],
   "version": "3.6.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
     "pytest-cov==7.1.0",
     "pytest-homeassistant-custom-component==0.13.354",
     "serialx==1.8.2",
-    "ttlock-ble==0.2.1",
+    "ttlock-ble==0.2.2",
 ]
 lint = [
     "ruff==0.16.4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from ttlock_ble import VirtualKey
+from ttlock_ble import DeviceInfo, VirtualKey
 from ttlock_ble.models.lock_version import LockVersion
 
 # Eagerly import the integration submodules so `unittest.mock.patch` can
@@ -141,6 +141,7 @@ def mock_ttlock_client() -> Generator[MagicMock]:
     instance.disconnect = AsyncMock(return_value=None)
     instance.query_state = AsyncMock(return_value=(0, 80))
     instance.get_operation_log = AsyncMock(return_value=[])
+    instance.get_device_info = AsyncMock(return_value=DeviceInfo())
     instance.lock = AsyncMock(return_value=None)
     instance.unlock = AsyncMock(return_value=None)
     instance.set_lock_sound = AsyncMock(return_value=None)
@@ -159,6 +160,7 @@ def mock_ttlock_connection() -> Generator[MagicMock]:
     instance.async_stop = AsyncMock(return_value=None)
     instance.async_query_state = AsyncMock(return_value=(0, 80))
     instance.async_get_operation_log = AsyncMock(return_value=[])
+    instance.async_get_device_info = AsyncMock(return_value=None)
     instance.async_lock = AsyncMock(return_value=None)
     instance.async_unlock = AsyncMock(return_value=None)
     instance.async_set_lock_sound = AsyncMock(return_value=None)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from ttlock_ble import LockEvent, TTLockError
+from ttlock_ble import DeviceInfo, LockEvent, TTLockError
 
 from custom_components.ttlock_ble.connection import (
     TtlockBleConnection,
@@ -722,3 +722,39 @@ async def test_set_lock_sound_raises_when_out_of_range(
         pytest.raises(TTLockError),
     ):
         await conn.async_set_lock_sound(enabled=True)
+
+
+async def test_device_info_returns_what_the_lock_reports(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    info = DeviceInfo(model="SN534-4P-T78-BELL", firmware_revision="6.5.20.24121101")
+    mock_ttlock_client.get_device_info = AsyncMock(return_value=info)
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_get_device_info() is info
+
+
+async def test_device_info_returns_none_when_device_missing(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    mock_ble_resolver.return_value = None
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_get_device_info() is None
+    mock_ttlock_client.connect.assert_not_awaited()
+
+
+async def test_device_info_that_breaks_the_link_costs_nothing_else(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    """Hardware strings are not worth failing the poll that carried them."""
+    mock_ttlock_client.get_device_info = AsyncMock(side_effect=TTLockError("link down"))
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_get_device_info() is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,10 +4,14 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from ttlock_ble import DeviceInfo
 
 from custom_components.ttlock_ble.coordinator import (
     TtlockBleDataUpdateCoordinator,
     _parse_lock_state,
+)
+from custom_components.ttlock_ble.device_description_store import (
+    TtlockBleDeviceDescriptionStore,
 )
 
 
@@ -24,17 +28,20 @@ def test_parse_lock_state_unknown(raw_state: int) -> None:
     assert _parse_lock_state(raw_state) is None
 
 
-def _mock_connection(*, query_return=(0, 80)) -> MagicMock:
+def _mock_connection(*, query_return=(0, 80), mac="AA:BB:CC:DD:EE:FF") -> MagicMock:
     conn = MagicMock()
+    conn.key = MagicMock(lockMac=mac)
     conn.async_query_state = AsyncMock(return_value=query_return)
     conn.async_get_operation_log = AsyncMock(return_value=[])
+    conn.async_get_device_info = AsyncMock(return_value=None)
     return conn
 
 
-def _coordinator(hass, connections):
+def _coordinator(hass, connections, descriptions=None):
     return TtlockBleDataUpdateCoordinator(
         hass=hass,
         connections=connections,
+        descriptions=descriptions or TtlockBleDeviceDescriptionStore(hass),
     )
 
 
@@ -471,3 +478,140 @@ async def test_learning_the_position_disarms_the_pending_read(hass) -> None:
     coordinator.async_apply_advertisement(MAC, _advertisement(unlocked=True))
     await hass.async_block_till_done()
     assert MAC not in coordinator._state_probes
+
+
+def _device_info(**overrides) -> DeviceInfo:
+    """Build the SDK's device info with the fields a lock actually answers."""
+    fields = {
+        "model": "SN534-4P-T78-BELL",
+        "hardware_revision": "1.7",
+        "firmware_revision": "6.5.20.24121101",
+    }
+    return DeviceInfo(**{**fields, **overrides})
+
+
+DESCRIPTION = {
+    "model": "SN534-4P-T78-BELL",
+    "hardware_version": "1.7",
+    "firmware_version": "6.5.20.24121101",
+}
+
+
+async def test_a_poll_learns_what_the_lock_reports_about_itself(hass) -> None:
+    conn = _mock_connection()
+    conn.async_get_device_info = AsyncMock(return_value=_device_info())
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    assert coordinator.async_device_description(MAC) == DESCRIPTION
+
+
+async def test_the_hardware_strings_are_read_once_per_run(hass) -> None:
+    """They are static, and each field costs its own BLE round trip."""
+    conn = _mock_connection()
+    conn.async_get_device_info = AsyncMock(return_value=_device_info())
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+
+    assert conn.async_get_device_info.await_count == 1
+
+
+async def test_a_read_that_did_not_reach_the_lock_is_tried_again(hass) -> None:
+    conn = _mock_connection()
+    conn.async_get_device_info = AsyncMock(side_effect=[None, _device_info()])
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+    assert coordinator.async_device_description(MAC) is None
+
+    await coordinator._async_update_data()
+    assert coordinator.async_device_description(MAC) == DESCRIPTION
+
+
+async def test_an_unchanged_description_is_not_written_again(hass) -> None:
+    """A restart re-reads the lock; nothing about the device has to move."""
+    descriptions = TtlockBleDeviceDescriptionStore(hass)
+    descriptions.async_remember(MAC, DESCRIPTION)
+    conn = _mock_connection()
+    conn.async_get_device_info = AsyncMock(return_value=_device_info())
+    coordinator = _coordinator(hass, {MAC: conn}, descriptions=descriptions)
+
+    with patch.object(descriptions, "async_remember") as remember:
+        await coordinator._async_update_data()
+
+    remember.assert_not_called()
+
+
+async def test_the_hardware_strings_reach_the_registry_device(
+    hass,
+    enable_custom_integrations,
+) -> None:
+    """`device_info` is only read at registration, so the device is updated in place."""
+    from homeassistant.helpers import device_registry
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.ttlock_ble.const import DOMAIN
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id="u")
+    entry.add_to_hass(hass)
+    registry = device_registry.async_get(hass)
+    registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, MAC.lower())},
+        model="Protocol 5.3",
+    )
+    conn = _mock_connection()
+    conn.async_get_device_info = AsyncMock(return_value=_device_info())
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    device = registry.async_get_device(identifiers={(DOMAIN, MAC.lower())})
+    assert device is not None
+    assert device.model == "SN534-4P-T78-BELL"
+    assert device.hw_version == "1.7"
+    assert device.sw_version == "6.5.20.24121101"
+
+
+async def test_a_field_the_lock_leaves_out_keeps_what_the_device_had(
+    hass,
+    enable_custom_integrations,
+) -> None:
+    """The protocol version is worth more on the device than an empty model."""
+    from homeassistant.helpers import device_registry
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.ttlock_ble.const import DOMAIN
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id="u")
+    entry.add_to_hass(hass)
+    registry = device_registry.async_get(hass)
+    registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, MAC.lower())},
+        model="Protocol 5.3",
+    )
+    conn = _mock_connection()
+    conn.async_get_device_info = AsyncMock(return_value=_device_info(model=None))
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    device = registry.async_get_device(identifiers={(DOMAIN, MAC.lower())})
+    assert device is not None
+    assert device.model == "Protocol 5.3"
+    assert device.sw_version == "6.5.20.24121101"
+
+
+async def test_a_lock_with_no_registry_device_is_still_remembered(hass) -> None:
+    """Nothing to stamp yet — the description still has to survive to setup."""
+    conn = _mock_connection()
+    conn.async_get_device_info = AsyncMock(return_value=_device_info())
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    assert coordinator.async_device_description(MAC) == DESCRIPTION

--- a/tests/test_device_description_store.py
+++ b/tests/test_device_description_store.py
@@ -1,0 +1,55 @@
+"""Coverage for the persisted per-lock hardware description."""
+
+from __future__ import annotations
+
+from custom_components.ttlock_ble.device_description_store import (
+    STORAGE_KEY,
+    STORAGE_VERSION,
+    TtlockBleDeviceDescriptionStore,
+)
+
+MAC = "AA:BB:CC:DD:EE:FF"
+DESCRIPTION = {
+    "model": "SN534-4P-T78-BELL",
+    "hardware_version": "1.7",
+    "firmware_version": "6.5.20.24121101",
+}
+
+
+async def test_load_tolerates_a_missing_file(hass) -> None:
+    store = TtlockBleDeviceDescriptionStore(hass)
+    await store.async_load()
+    assert store.get(MAC) is None
+
+
+async def test_load_restores_the_persisted_description(hass, hass_storage) -> None:
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {MAC: DESCRIPTION},
+    }
+    store = TtlockBleDeviceDescriptionStore(hass)
+    await store.async_load()
+    assert store.get(MAC) == DESCRIPTION
+
+
+async def test_remember_replaces_the_earlier_answer(hass) -> None:
+    """A firmware upgrade changes what the lock reports; the newer answer wins."""
+    store = TtlockBleDeviceDescriptionStore(hass)
+    store.async_remember(MAC, DESCRIPTION)
+    upgraded = {**DESCRIPTION, "firmware_version": "6.5.21.25010101"}
+    store.async_remember(MAC, upgraded)
+    assert store.get(MAC) == upgraded
+
+
+async def test_remember_writes_the_delayed_snapshot(hass, hass_storage) -> None:
+    store = TtlockBleDeviceDescriptionStore(hass)
+    store.async_remember(MAC, DESCRIPTION)
+    await store._store.async_save(store._snapshot())
+    assert hass_storage[STORAGE_KEY]["data"] == {MAC: DESCRIPTION}
+
+
+async def test_locks_keep_separate_descriptions(hass) -> None:
+    other = "11:22:33:44:55:66"
+    store = TtlockBleDeviceDescriptionStore(hass)
+    store.async_remember(MAC, DESCRIPTION)
+    assert store.get(other) is None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -155,3 +155,38 @@ async def test_diagnostics_decoded_is_none_for_a_foreign_payload(
         diagnostics = await async_get_config_entry_diagnostics(hass, setup_integration)
 
     assert diagnostics["advertisements"][sample_virtual_key.lockMac]["decoded"] is None
+
+
+async def test_diagnostics_reports_no_description_before_a_lock_is_read(
+    hass,
+    setup_integration,
+    sample_virtual_key,
+) -> None:
+    from custom_components.ttlock_ble.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, setup_integration)
+    assert diagnostics["device_descriptions"][sample_virtual_key.lockMac] is None
+
+
+async def test_diagnostics_carries_the_hardware_strings(
+    hass,
+    setup_integration,
+    sample_virtual_key,
+) -> None:
+    """Model and firmware are the first thing a bug report is asked for."""
+    from custom_components.ttlock_ble.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+
+    description = {
+        "model": "SN534-4P-T78-BELL",
+        "hardware_version": "1.7",
+        "firmware_version": "6.5.20.24121101",
+    }
+    coordinator = setup_integration.runtime_data.coordinator
+    coordinator._descriptions.async_remember(sample_virtual_key.lockMac, description)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, setup_integration)
+    assert diagnostics["device_descriptions"][sample_virtual_key.lockMac] == description

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -4,13 +4,20 @@ from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, format_m
 
 from custom_components.ttlock_ble.const import DOMAIN, MANUFACTURER
 from custom_components.ttlock_ble.coordinator import TtlockBleDataUpdateCoordinator
+from custom_components.ttlock_ble.device_description_store import (
+    TtlockBleDeviceDescriptionStore,
+)
 from custom_components.ttlock_ble.entity import TtlockBleEntity
 
 
-def _entity(hass, key) -> TtlockBleEntity:
+def _entity(hass, key, description=None) -> TtlockBleEntity:
+    descriptions = TtlockBleDeviceDescriptionStore(hass)
+    if description is not None:
+        descriptions.async_remember(key.lockMac, description)
     coordinator = TtlockBleDataUpdateCoordinator(
         hass=hass,
         connections={},
+        descriptions=descriptions,
     )
     return TtlockBleEntity(coordinator, key)
 
@@ -37,8 +44,45 @@ async def test_entity_device_info_manufacturer(hass, sample_virtual_key) -> None
 async def test_entity_device_info_model_carries_protocol(
     hass, sample_virtual_key
 ) -> None:
+    """Until a lock is read, its protocol version is all that is known."""
     info = _entity(hass, sample_virtual_key).device_info
     assert info["model"] == "Protocol 5.3"
+    assert info["hw_version"] is None
+    assert info["sw_version"] is None
+
+
+async def test_entity_device_info_prefers_what_the_lock_reported(
+    hass, sample_virtual_key
+) -> None:
+    info = _entity(
+        hass,
+        sample_virtual_key,
+        description={
+            "model": "SN534-4P-T78-BELL",
+            "hardware_version": "1.7",
+            "firmware_version": "6.5.20.24121101",
+        },
+    ).device_info
+    assert info["model"] == "SN534-4P-T78-BELL"
+    assert info["hw_version"] == "1.7"
+    assert info["sw_version"] == "6.5.20.24121101"
+
+
+async def test_entity_device_info_keeps_the_protocol_when_no_model_was_read(
+    hass, sample_virtual_key
+) -> None:
+    """A lock that answers the firmware but not the model keeps both truths."""
+    info = _entity(
+        hass,
+        sample_virtual_key,
+        description={
+            "model": None,
+            "hardware_version": None,
+            "firmware_version": "6.5.20.24121101",
+        },
+    ).device_info
+    assert info["model"] == "Protocol 5.3"
+    assert info["sw_version"] == "6.5.20.24121101"
 
 
 async def test_entity_falls_back_to_lock_name_when_alias_missing(

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -661,11 +661,15 @@ def test_lock_sync_from_coordinator_no_snapshot_keeps_state(
     from unittest.mock import MagicMock
 
     from custom_components.ttlock_ble.coordinator import TtlockBleDataUpdateCoordinator
+    from custom_components.ttlock_ble.device_description_store import (
+        TtlockBleDeviceDescriptionStore,
+    )
     from custom_components.ttlock_ble.lock import TtlockBleLock
 
     coordinator = TtlockBleDataUpdateCoordinator(
         hass,
         {},
+        TtlockBleDeviceDescriptionStore(hass),
     )
     coordinator.data = {}
     entity = TtlockBleLock(coordinator, sample_virtual_key, MagicMock())

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -151,11 +151,15 @@ def test_battery_sync_from_coordinator_no_snapshot_keeps_value(
     """An empty coordinator snapshot leaves `_attr_native_value` untouched."""
 
     from custom_components.ttlock_ble.coordinator import TtlockBleDataUpdateCoordinator
+    from custom_components.ttlock_ble.device_description_store import (
+        TtlockBleDeviceDescriptionStore,
+    )
     from custom_components.ttlock_ble.sensor import TtlockBleBatterySensor
 
     coordinator = TtlockBleDataUpdateCoordinator(
         hass,
         {},
+        TtlockBleDeviceDescriptionStore(hass),
     )
     coordinator.data = {}
     entity = TtlockBleBatterySensor(coordinator, sample_virtual_key)

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,7 @@ wheels = [
 
 [[package]]
 name = "ha-ttlock-ble"
-version = "3.6.0"
+version = "3.6.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -1155,7 +1155,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.354" },
     { name = "serialx", specifier = "==1.8.2" },
-    { name = "ttlock-ble", specifier = "==0.2.0" },
+    { name = "ttlock-ble", specifier = "==0.2.2" },
 ]
 lint = [
     { name = "mypy", specifier = "==2.3.1" },
@@ -2734,7 +2734,7 @@ wheels = [
 
 [[package]]
 name = "ttlock-ble"
-version = "0.2.0"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
@@ -2742,9 +2742,9 @@ dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/49/a686388fe10fce1481f3c59915cd8b2fb96d93347b79ee2a7e2af4e35464/ttlock_ble-0.2.0.tar.gz", hash = "sha256:3247f8c9749102e64a511187ff87174e407a1f9c6af6e99e1901af6baa25cc12", size = 47744, upload-time = "2026-08-25T23:49:32.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/1e/a26b29e09afa5d8368d56aa99229309ecbeef0449233cbe943b8f31378cc/ttlock_ble-0.2.2.tar.gz", hash = "sha256:443dc0fb5470a9fcbc8d089d5d85547273b3136f1f760111d3471bc6e0c13ed1", size = 51251, upload-time = "2026-08-26T19:46:34.79Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/dd/75fc1708345e096cd80cdf4890c6e71b406efb84ce8c5538364b01683f9b/ttlock_ble-0.2.0-py3-none-any.whl", hash = "sha256:996833038f1604ba811a3cb3d8db8e8b5dad01557794bd1289ab733663e5d511", size = 61613, upload-time = "2026-08-25T23:49:31.171Z" },
+    { url = "https://files.pythonhosted.org/packages/43/73/afe017051116013e2f2ba1fdbdb6bee17a1646e44c277252f12c28badab9/ttlock_ble-0.2.2-py3-none-any.whl", hash = "sha256:d37263f50a035c0f0547c9a6cba1de64659388871610b664cd39f6c9130d6553", size = 65836, upload-time = "2026-08-26T19:46:33.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changes

The device page for a lock now carries what the lock itself reports — model, hardware revision and firmware revision — instead of describing it by protocol version alone.

Before, a lock appeared as `Protocol 5.3` with no hardware or firmware information. It now appears as its actual model (`SN534-4P-T78-BELL`), with hardware `1.7` and firmware `6.5.20.24121101` filled in.

## How the values are obtained

`ttlock-ble` 0.2.2 exposes `get_device_info()`, which reads the standard Bluetooth SIG Device Information Service. Three constraints shape how this integration uses it:

- **Nothing connects to fetch them.** The read rides on a poll that has just reached the lock. A lock only grants a BLE session while it is awake, and hardware strings are not worth waking one for.
- **Read once per Home Assistant run, remembered per MAC.** The values are static until a firmware upgrade changes them, so they are persisted and shown immediately after a restart, then refreshed by the first successful poll of the run.
- **The registry device is updated in place.** An entity's `device_info` is only read when the entity is registered, so a value learned mid-run would otherwise wait for the next restart to appear.

A field the lock does not answer leaves the existing value untouched: the model falls back to the protocol version carried by the key, which is more useful than an empty string. The diagnostics dump carries the stored strings as well.

## Verification

Verified against a physical lock: the model, hardware and firmware read off it reach the device registry, and the values survive a restart without opening a session.

Lint, typing and the full test suite pass; coverage is at 100%.

## Dependency

Bumps the `ttlock-ble` pin to 0.2.2 in both `manifest.json` and `pyproject.toml`.