### PR TITLE
fix: cancel the coordinator's timers and stop blanking the device

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,8 @@ device_description_store.py
 
 `data/` is a package, one class per file, re-exported from `data/__init__.py`. `data/__init__.py` defines `TtlockBleConfigEntry = ConfigEntry[TtlockBleData]`; `data/runtime.py` defines the `TtlockBleData(keys, virtual_keys, connections, coordinator, bluetooth_unsubs, first_refresh)` dataclass; `data/log_cursor.py` defines `TtlockBleLogCursor(records, seeded, on_move)`, which `record_store.py` fills and each connection resumes its operation log from. State lives on `entry.runtime_data` (auto-discarded on unload), never on `hass.data`.
 
+The two stores are the deliberate exception: `record_store.py` and `device_description_store.py` each expose a `singleton`-decorated getter, so one instance is shared per Home Assistant instance rather than per entry. Their files are keyed by MAC and hold every lock of every entry, and an instance writes the whole file from what it loaded — two of them would take turns dropping what the other had written since.
+
 ### Config flow surface
 
 `config_flow.py` implements the user-facing steps, sharing one module-level `_credentials_schema` builder for the credential ones and one `_manual_key_schema` for the manual one:
@@ -136,7 +138,10 @@ Every cloud call in the flow, `_async_fetch_keys` included, maps its exceptions 
 - A dispatcher forwarder: any push event the SDK emits is fanned out on `ttlock_ble_event_<mac>` so the lock, sensor, and event entities can subscribe. The BLE drop is announced from bleak's own callback, not from the teardown that follows the cooldown, so the connectivity sensor does not claim a live link for five minutes after the link died.
 - A retry timer for the operation log: a read that did not reach the lock leaves the advertised records flag up, and the lock then repeats the very same payload, which HA's bluetooth manager does not forward a second time. Waiting for another advertisement to retry therefore waits forever, so `coordinator.py` arms a timer instead and cancels it when an advertisement reports the flag down.
 - Backlog seeding: on a lock with no restored cursor, the first operation-log fetch that actually reaches it only fills `_seen_records` and dispatches nothing. The lock returns everything unsynced since its last cursor sync, and replaying that history as live events would fire automations for unlocks from days ago. Tying it to a *successful* fetch matters — a lock out of range at setup must not spend its seeding pass on a poll that read nothing. `record_store.py` persists the cursor, so the pass runs once per lock rather than once per HA start; keying it to the start is what made a restart swallow whatever happened at the door just after it.
+- A connect step that catches every exception, not just `TTLockError`: the SDK leaves `start_notify` unwrapped, so bleak's own `BleakError` escaped the wrapper each command path relies on, and the half-open session is closed rather than left to the firmware's idle timeout.
 - A refusal to reconnect after `async_stop`: a late caller would otherwise take the lock's single central slot with no maintain loop left to release it.
+
+`coordinator.py` overrides `async_shutdown` to cancel both timer dicts. Nothing else does, and the log retry re-arms itself while the lock still advertises unsynced records — a flag only an advertisement lowers, and the subscription that would deliver one is gone by the time an entry unloads. Left armed, the retry outlived the entry, kept the coordinator and its connections alive with it, and logged against a lock the user may have removed, every cooldown, for the rest of the run.
 
 ### Last-seen sensor
 
@@ -163,6 +168,7 @@ The diagnostics dump carries the last advertisement per lock, raw bytes included
 
 - **Nothing connects for them.** The read rides on a poll that just reached the lock, in `coordinator.py`'s `_async_describe`. A lock only grants a session while it is awake, and hardware strings are not worth waking one for.
 - **Once per Home Assistant run, not once ever.** The values are static until a firmware upgrade changes them, so the store is what a restart displays, and the first successful poll of each run re-reads and replaces it.
+- **An unknown field is left out of `device_info`, not spelled as `None`.** `DeviceInfo` is a TypedDict, and every key present is written to the registry device — `None` included, since only an absent key means "leave this alone". Spelling out an unknown version blanked what a poll had already stamped and reverted the model to the protocol fallback, on any entity re-registration before the store had an answer.
 - **The registry device is updated in place.** An entity's `device_info` is only read when the entity is registered, so a description learned mid-run would otherwise wait for the next restart to appear. A field the lock did not answer is left untouched rather than blanked — `entity.py` falls back to the key's protocol version for the model, which beats an empty one.
 
 ### Lock entity

--- a/README.md
+++ b/README.md
@@ -17,21 +17,23 @@ Local control of TTLock smart locks over Bluetooth, for [Home Assistant](https:/
 - **2FA-aware config flow** — handles TTLock's "new device" verification by emailing a one-time code and prompting for it.
 - **Works without a cloud account** — a lock initialised locally can be added by entering its key directly, no TTLock account involved at any point.
 - **Passive state tracking** — the bolt position and battery level are read from the lock's own BLE advertisements, with no connection and no battery cost. This is what catches an auto-lock or an operation done from the official app.
-- **Persistent BLE session with a post-drop cooldown** — keeps the link warm to receive push events, and waits before reconnecting so a lock in idle-sleep isn't thrashed.
+- **Connects only on demand** — nothing is held open. A session is opened when a command needs the lock, when the lock advertises that it has records worth reading, or when the permanent connection option asks for one.
 - **Reauth + reconfigure** — re-prompt for credentials in place when the cloud rejects the cached login, or edit them via the integration's three-dot menu.
 - **Diagnostics** — downloadable dump with credentials/keys redacted.
 - **Translations** — English and Brazilian Portuguese (parity enforced by tests).
 
 ## Entities
 
-Each configured lock produces one HA device with four entities:
+Each configured lock produces one HA device, named with the model, hardware and firmware the lock reports about itself, carrying up to six entities:
 
 | Entity | Domain | Purpose |
 |---|---|---|
 | `lock.<alias>` | `lock` | Locked/unlocked state, with optimistic updates, `locking`/`unlocking` transitional states and a post-command settle window. |
 | `sensor.<alias>_battery` | `sensor` | Battery percentage (diagnostic). |
-| `binary_sensor.<alias>_connection` | `binary_sensor` | Live BLE link state (connectivity, diagnostic). |
+| `binary_sensor.<alias>_bluetooth_connection` | `binary_sensor` | Whether a BLE session is open right now (connectivity, diagnostic). A healthy idle lock holds none, so `off` says nothing about whether the lock is reachable. |
 | `event.<alias>_log` | `event` | Fires for every new operation-log record read from the lock. |
+| `sensor.<alias>_last_seen` | `sensor` | When the lock was last heard from, read from HA's own advertisement history (diagnostic). |
+| `switch.<alias>_sound` | `switch` | The lock's keypad/lock beep. Assumed state — the firmware reports no readback — and only created for an admin key that carries an admin passcode, which a manually entered key usually does not. |
 
 The event entity classifies each record as `unlock`, `lock`, `unlock_failed`, `password_change` or `other`, and attaches `record_type` and `battery` always, plus `timestamp`, `uid`, `credential`, `key_id` and `accessory_battery` when the record carries them. `credential` is only populated for record types where the value is an identifier (card number, fingerprint id, fob MAC) — record types where it would be a working door code never expose it.
 
@@ -65,11 +67,11 @@ The Bluetooth radio HA already manages (USB dongle, built-in adapter, or proxy) 
 
 ## Options
 
-Settings → Devices & Services → TTLock BLE → **Configure** lets you tune:
+Settings → Devices & Services → TTLock BLE → **Configure** exposes one setting:
 
-- `scan_interval` (default 3600 s, minimum 60 s) — how often the coordinator opens a BLE session to read state. Every advertisement received postpones the next poll, so a lock in range is rarely polled at all; lowering this only adds connections (and battery drain) for a lock that has gone quiet.
-- `reconnect_interval` (default 300 s, minimum 10 s) — how long the connection layer waits after the lock drops the BLE session before reconnecting. The lock closes every idle session within seconds, so this is effectively how often a session is reopened to listen for push events.
-- `permanent_connection` (default off) — reconnect immediately after every drop, keeping the session open as continuously as the lock allows. Overrides `reconnect_interval` and increases the lock's battery drain; push events (keypad, auto-lock) arrive in real time in exchange.
+- `permanent_connection` (default off) — hold a BLE session open, reopening it the instant the lock drops it. Push events (keypad, auto-lock) then arrive in real time, and the lock's battery pays for it: the firmware closes an idle session within seconds, so this reconnects about as often. With the option off nothing is held open and nothing reconnects.
+
+There is no polling interval and no reconnect pacing to configure. Earlier releases exposed `scan_interval` and `reconnect_interval`; both are gone, because nothing polls on a schedule any more — state arrives from the lock's own advertisements, and a session is opened only when something actually needs one.
 
 To edit credentials without removing and re-adding, use the integration's three-dot menu → **Reconfigure**.
 
@@ -78,9 +80,10 @@ To edit credentials without removing and re-adding, use the integration's three-
 The lock's TTLock firmware aggressively closes idle BLE sessions (~5 s of silence and it drops). The integration:
 
 1. Reads the bolt position and battery level straight out of the lock's BLE advertisements. This costs no connection at all and is the only channel that reports an operation performed while Home Assistant is not connected — an auto-lock, the official app, a keypad code.
-2. Keeps a persistent BLE session via `connection.py`, reconnecting on every drop signalled by bleak, and waiting out the configured `reconnect_interval` before doing so — or none at all with `permanent_connection`.
+2. Opens a session only when there is a reason to: a `lock`/`unlock` command, an advertisement announcing unsynced operation records, or the first bolt position while none is known at all. With `permanent_connection` on, `connection.py` also holds one open and reopens it on every drop bleak signals.
 3. After a user-initiated `lock`/`unlock`, the SDK keeps the link alive for 25 s so push events (the lock's reports of keypad operations, auto-locks, etc.) reach Home Assistant in real time.
 4. Each push event carries the decoded `lock_state` and `battery` when the firmware emits a heartbeat-style payload, letting the entities update without a follow-up query.
+5. While a session is open anyway, the lock is asked what it is — model, hardware and firmware — and the answer is remembered, so a restart shows it without connecting.
 
 ## Useful commands
 
@@ -123,8 +126,10 @@ custom_components/ttlock_ble/
 ├── lock.py            # TtlockBleLock: LockEntity backed by the connection
 ├── manifest.json
 ├── manual_key.py      # TtlockBleManualKey: key entry for cloud-less locks
-├── options_flow.py    # TtlockBleOptionsFlow: scan_interval, reconnect_interval, permanent_connection
-├── sensor.py          # TtlockBleBatterySensor backed by polls + pushes
+├── options_flow.py    # TtlockBleOptionsFlow: permanent_connection
+├── record_store.py    # persisted operation-log cursor per lock
+├── sensor.py          # TtlockBleBatterySensor + TtlockBleLastSeenSensor
+├── switch.py          # TtlockBleSoundSwitch: the lock's beep (admin keys only)
 └── translations/
     ├── en.json
     └── pt-BR.json

--- a/custom_components/ttlock_ble/__init__.py
+++ b/custom_components/ttlock_ble/__init__.py
@@ -22,8 +22,8 @@ from .connection import TtlockBleConnection
 from .const import CONF_PERMANENT_CONNECTION, DOMAIN, LOGGER
 from .coordinator import TtlockBleDataUpdateCoordinator
 from .data import TtlockBleData, TtlockBleLogCursor
-from .device_description_store import TtlockBleDeviceDescriptionStore
-from .record_store import TtlockBleRecordStore
+from .device_description_store import async_get_device_description_store
+from .record_store import async_get_record_store
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -102,8 +102,7 @@ async def async_setup_entry(
     virtual_keys = [VirtualKey.from_dict(dict(k)) for k in stored_keys]
 
     permanent_connection = bool(entry.options.get(CONF_PERMANENT_CONNECTION, False))
-    record_store = TtlockBleRecordStore(hass)
-    await record_store.async_load()
+    record_store = await async_get_record_store(hass)
     connections: dict[str, TtlockBleConnection] = {
         key.lockMac: TtlockBleConnection(
             hass,
@@ -123,8 +122,7 @@ async def async_setup_entry(
         for connection in connections.values():
             await connection.async_start()
 
-    description_store = TtlockBleDeviceDescriptionStore(hass)
-    await description_store.async_load()
+    description_store = await async_get_device_description_store(hass)
     coordinator = TtlockBleDataUpdateCoordinator(
         hass=hass,
         connections=connections,

--- a/custom_components/ttlock_ble/connection.py
+++ b/custom_components/ttlock_ble/connection.py
@@ -342,8 +342,18 @@ class TtlockBleConnection:
         )
         try:
             await client.connect()
-        except TTLockError as exc:
+        except Exception as exc:  # noqa: BLE001
+            # `TTLockError` alone is not enough: the SDK's connect path
+            # leaves `start_notify` unwrapped, so bleak raises a plain
+            # `BleakError` when the link drops between the connect and
+            # the subscription. Letting that out bypasses the wrapper
+            # every command path relies on, and the user gets an unknown
+            # error with a traceback instead of a failure that names the
+            # lock. The half-open session is closed here rather than
+            # left to the firmware's idle timeout.
             LOGGER.debug("BLE connect failed for %s: %s", self._key.lockMac, exc)
+            with contextlib.suppress(Exception):
+                await client.disconnect()
             return None
         client.add_event_listener(self._on_event)
         self._client = client

--- a/custom_components/ttlock_ble/coordinator.py
+++ b/custom_components/ttlock_ble/coordinator.py
@@ -93,6 +93,27 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
         self._log_retries: dict[str, CALLBACK_TYPE] = {}
         self._state_probes: dict[str, CALLBACK_TYPE] = {}
 
+    async def async_shutdown(self) -> None:
+        """
+        Cancel the pending timers along with the coordinator itself.
+
+        Neither timer is cancelled by anything else, and the log retry
+        re-arms itself while the lock still advertises unsynced records
+        - a flag only an advertisement lowers, and the subscription that
+        would deliver one is gone by the time an entry unloads. Left
+        armed, the retry outlives the entry it belongs to, keeps a
+        stopped connection and the whole entry alive with it, and logs
+        against a lock the user may have removed, every cooldown, for
+        the rest of the Home Assistant run.
+        """
+        for cancel in self._log_retries.values():
+            cancel()
+        self._log_retries.clear()
+        for cancel in self._state_probes.values():
+            cancel()
+        self._state_probes.clear()
+        await super().async_shutdown()
+
     @property
     def connections(self) -> dict[str, TtlockBleConnection]:
         """Return the per-MAC connection map this coordinator polls."""

--- a/custom_components/ttlock_ble/device_description_store.py
+++ b/custom_components/ttlock_ble/device_description_store.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from homeassistant.helpers.singleton import singleton
 from homeassistant.helpers.storage import Store
+from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN
 
@@ -61,3 +63,23 @@ class TtlockBleDeviceDescriptionStore:
     def _snapshot(self) -> dict[str, TtlockBleDeviceDescription]:
         """Render the in-memory descriptions as the JSON the store writes."""
         return dict(self._descriptions)
+
+
+STORE_KEY: HassKey[TtlockBleDeviceDescriptionStore] = HassKey(
+    f"{DOMAIN}_device_description_store"
+)
+
+
+@singleton(STORE_KEY, async_=True)
+async def async_get_device_description_store(
+    hass: HomeAssistant,
+) -> TtlockBleDeviceDescriptionStore:
+    """
+    Return the one store this Home Assistant instance shares.
+
+    One instance per entry writes the whole file from what it loaded, so
+    two entries would take turns dropping each other's newer answers.
+    """
+    store = TtlockBleDeviceDescriptionStore(hass)
+    await store.async_load()
+    return store

--- a/custom_components/ttlock_ble/entity.py
+++ b/custom_components/ttlock_ble/entity.py
@@ -48,15 +48,24 @@ class TtlockBleEntity(CoordinatorEntity[TtlockBleDataUpdateCoordinator]):
         mac = format_mac(self._key.lockMac)
         description = self.coordinator.async_device_description(self._key.lockMac)
         model = None if description is None else description["model"]
-        return DeviceInfo(
+        device_info = DeviceInfo(
             identifiers={(DOMAIN, mac)},
             connections={(CONNECTION_BLUETOOTH, mac)},
             name=self._key.lockAlias or self._key.lockName or self._key.lockMac,
             manufacturer=MANUFACTURER,
             model=model or self._protocol_model,
-            hw_version=None if description is None else description["hardware_version"],
-            sw_version=None if description is None else description["firmware_version"],
         )
+        if description is None:
+            return device_info
+        # A key present here is written to the registry device, `None`
+        # included, and only a key left out means "leave this alone".
+        # Spelling out an unknown version would blank the one a poll
+        # stamped on the device before this entity was registered.
+        if description["hardware_version"]:
+            device_info["hw_version"] = description["hardware_version"]
+        if description["firmware_version"]:
+            device_info["sw_version"] = description["firmware_version"]
+        return device_info
 
     @property
     def _protocol_model(self) -> str:

--- a/custom_components/ttlock_ble/record_store.py
+++ b/custom_components/ttlock_ble/record_store.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypedDict
 
+from homeassistant.helpers.singleton import singleton
 from homeassistant.helpers.storage import Store
+from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN
 
@@ -89,3 +91,21 @@ class TtlockBleRecordStore:
     def _snapshot(self) -> dict[str, TtlockBleStoredCursor]:
         """Render the in-memory cursors as the JSON the store writes."""
         return dict(self._cursors)
+
+
+STORE_KEY: HassKey[TtlockBleRecordStore] = HassKey(f"{DOMAIN}_record_store")
+
+
+@singleton(STORE_KEY, async_=True)
+async def async_get_record_store(hass: HomeAssistant) -> TtlockBleRecordStore:
+    """
+    Return the one store this Home Assistant instance shares.
+
+    The file is keyed by MAC and holds every lock of every entry, so
+    one instance per entry means the last one to write replaces what the
+    others had loaded, and a lock added to a second entry can lose the
+    cursor another entry moved in the meantime.
+    """
+    store = TtlockBleRecordStore(hass)
+    await store.async_load()
+    return store

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from bleak import BleakError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from ttlock_ble import DeviceInfo, LockEvent, TTLockError
 
@@ -758,3 +759,33 @@ async def test_device_info_that_breaks_the_link_costs_nothing_else(
     mock_ttlock_client.get_device_info = AsyncMock(side_effect=TTLockError("link down"))
     conn = TtlockBleConnection(hass, sample_virtual_key)
     assert await conn.async_get_device_info() is None
+
+
+async def test_a_bleak_error_from_connect_is_not_left_raw(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    """The SDK leaves `start_notify` unwrapped, so bleak's own error can escape."""
+    mock_ttlock_client.connect = AsyncMock(side_effect=BleakError("link dropped"))
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+
+    with pytest.raises(TTLockError):
+        await conn.async_unlock()
+    assert await conn.async_query_state() is None
+
+
+async def test_a_half_open_session_is_closed_when_connect_fails(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    """The lock has one central slot; a session nobody owns has to go back."""
+    mock_ttlock_client.connect = AsyncMock(side_effect=BleakError("notify failed"))
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+
+    assert await conn.async_query_state() is None
+
+    mock_ttlock_client.disconnect.assert_awaited()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -615,3 +615,61 @@ async def test_a_lock_with_no_registry_device_is_still_remembered(hass) -> None:
     await coordinator._async_update_data()
 
     assert coordinator.async_device_description(MAC) == DESCRIPTION
+
+
+async def test_shutdown_cancels_the_pending_log_retry(hass) -> None:
+    """Left armed, the retry re-arms itself for the rest of the HA run."""
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    with patch.object(coordinator, "async_request_refresh"):
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, records=True)
+        )
+        await hass.async_block_till_done()
+    assert MAC in coordinator._log_retries
+
+    await coordinator.async_shutdown()
+
+    assert coordinator._log_retries == {}
+
+
+async def test_shutdown_cancels_the_pending_state_probe(hass) -> None:
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    with patch.object(coordinator, "async_request_refresh"):
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, dormant=True)
+        )
+        await hass.async_block_till_done()
+    assert MAC in coordinator._state_probes
+
+    await coordinator.async_shutdown()
+
+    assert coordinator._state_probes == {}
+
+
+async def test_a_cancelled_retry_never_fires_again(hass) -> None:
+    """The unloaded entry must not keep reading a lock it no longer owns."""
+
+    from homeassistant.util import dt as dt_util
+    from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+    from custom_components.ttlock_ble.coordinator import LOG_RETRY_COOLDOWN_SECONDS
+
+    conn = _mock_connection()
+    coordinator = _log_coordinator(hass, conn)
+    with patch.object(coordinator, "async_request_refresh"):
+        coordinator.async_apply_advertisement(
+            MAC, _advertisement(unlocked=False, records=True)
+        )
+        await hass.async_block_till_done()
+    await coordinator.async_shutdown()
+    conn.async_get_operation_log.reset_mock()
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=LOG_RETRY_COOLDOWN_SECONDS + 1),
+    )
+    await hass.async_block_till_done()
+
+    conn.async_get_operation_log.assert_not_awaited()

--- a/tests/test_device_description_store.py
+++ b/tests/test_device_description_store.py
@@ -53,3 +53,17 @@ async def test_locks_keep_separate_descriptions(hass) -> None:
     store = TtlockBleDeviceDescriptionStore(hass)
     store.async_remember(MAC, DESCRIPTION)
     assert store.get(other) is None
+
+
+async def test_every_entry_shares_one_store(hass) -> None:
+    """Two instances over one storage key take turns dropping each other's writes."""
+    from custom_components.ttlock_ble.device_description_store import (
+        async_get_device_description_store,
+    )
+
+    first = await async_get_device_description_store(hass)
+    first.async_remember(MAC, DESCRIPTION)
+    second = await async_get_device_description_store(hass)
+
+    assert second is first
+    assert second.get(MAC) == DESCRIPTION

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -47,8 +47,10 @@ async def test_entity_device_info_model_carries_protocol(
     """Until a lock is read, its protocol version is all that is known."""
     info = _entity(hass, sample_virtual_key).device_info
     assert info["model"] == "Protocol 5.3"
-    assert info["hw_version"] is None
-    assert info["sw_version"] is None
+    # Spelled out, an unknown version would blank whatever a poll had
+    # already stamped on the registry device; left out, it is kept.
+    assert "hw_version" not in info
+    assert "sw_version" not in info
 
 
 async def test_entity_device_info_prefers_what_the_lock_reported(
@@ -82,6 +84,7 @@ async def test_entity_device_info_keeps_the_protocol_when_no_model_was_read(
         },
     ).device_info
     assert info["model"] == "Protocol 5.3"
+    assert "hw_version" not in info
     assert info["sw_version"] == "6.5.20.24121101"
 
 

--- a/tests/test_record_store.py
+++ b/tests/test_record_store.py
@@ -80,3 +80,15 @@ async def test_an_empty_backlog_still_marks_the_lock_seeded(hass, hass_storage) 
     await restored.async_load()
     assert restored.seen(MAC) == set()
     assert restored.is_seeded(MAC) is True
+
+
+async def test_every_entry_shares_one_store(hass) -> None:
+    """Two instances over one storage key take turns dropping each other's writes."""
+    from custom_components.ttlock_ble.record_store import async_get_record_store
+
+    first = await async_get_record_store(hass)
+    first.async_remember(MAC, {1, 2})
+    second = await async_get_record_store(hass)
+
+    assert second is first
+    assert second.seen(MAC) == {1, 2}


### PR DESCRIPTION
Follow-up to the review of everything queued for 3.7.0. Five defects, none of which changes lock state or loses data, but the first one leaks for the lifetime of the Home Assistant process.

## 1. The operation-log retry timer outlived the config entry

`_log_retries` and `_state_probes` hold `async_call_later` handles that nothing cancelled on unload. The retry is worse than a single late fire: it re-arms itself whenever the lock still advertises unsynced records, and that flag is lowered only by an advertisement — whose subscription is removed when the entry unloads. So an orphaned coordinator re-armed every cooldown for the rest of the run, held its connections and the config entry in memory, and logged `get_operation_log: no client for <MAC>` at warning level, including for an integration the user had already removed. Reached by any reload: changing the one option, reauth, reconfigure, or an update.

`async_shutdown` now cancels both, which Home Assistant already calls on unload. Three tests cover it, and all three fail without the change.

## 2. An unknown version blanked what the device already had

`device_info` spelled a missing hardware or firmware version as `None`. `DeviceInfo` is a TypedDict and every key present is written to the registry device — only an absent key means "leave this alone". Any entity re-registration before the store had an answer therefore blanked the versions and reverted the model to the protocol fallback, undoing what the previous poll had stamped. The keys are now left out unless there is a value.

## 3. Two entries took turns dropping each other's writes

`record_store.py` and `device_description_store.py` were instantiated per entry over one storage key each. Both files are keyed by MAC and hold every lock of every entry, and an instance rewrites the whole file from what it loaded — so an install with two entries lost whichever delta the other had written since. Each store now exposes a `singleton`-decorated getter, shared per Home Assistant instance.

## 4. bleak's own error escaped the command wrapper

The connect step caught only `TTLockError`, while the SDK leaves `start_notify` unwrapped. A link that dropped between the connect and the subscription raised a bare `BleakError` past the wrapper every command path relies on, so the user got an unknown error with a traceback instead of a failure naming the lock. The half-open session is now closed instead of being left to the firmware's idle timeout.

## 5. The README described the previous release

It is the page HACS renders on the install screen, and it still told users to configure `scan_interval` and `reconnect_interval` — both removed in this release — and described the persistent-session model that the connect-on-demand refactor inverted. It also said "four entities" and listed neither of the two this release adds. Corrected, along with the layout block and the connectivity sensor's entity id.

## Verification

Lint, typing and the full suite pass with coverage at 100%. Verified on a physical lock: the entry reloads cleanly, every entity comes back, and the device keeps the model, hardware and firmware it had been given.