### PR TITLE
chore(deps): bump ttlock-ble to 0.3.0

### DIFF
--- a/custom_components/ttlock_ble/manifest.json
+++ b/custom_components/ttlock_ble/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/roquerodrigo/ha-ttlock-ble/issues",
   "requirements": [
-    "ttlock-ble==0.2.2"
+    "ttlock-ble==0.3.0"
   ],
   "version": "3.7.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
     "pytest-cov==7.1.0",
     "pytest-homeassistant-custom-component==0.13.354",
     "serialx==1.8.2",
-    "ttlock-ble==0.2.2",
+    "ttlock-ble==0.3.0",
 ]
 lint = [
     "ruff==0.16.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,7 @@ wheels = [
 
 [[package]]
 name = "ha-ttlock-ble"
-version = "3.6.1"
+version = "3.7.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -1155,7 +1155,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.354" },
     { name = "serialx", specifier = "==1.8.2" },
-    { name = "ttlock-ble", specifier = "==0.2.2" },
+    { name = "ttlock-ble", specifier = "==0.3.0" },
 ]
 lint = [
     { name = "mypy", specifier = "==2.3.1" },
@@ -2734,7 +2734,7 @@ wheels = [
 
 [[package]]
 name = "ttlock-ble"
-version = "0.2.2"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
@@ -2742,9 +2742,9 @@ dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/1e/a26b29e09afa5d8368d56aa99229309ecbeef0449233cbe943b8f31378cc/ttlock_ble-0.2.2.tar.gz", hash = "sha256:443dc0fb5470a9fcbc8d089d5d85547273b3136f1f760111d3471bc6e0c13ed1", size = 51251, upload-time = "2026-08-26T19:46:34.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/c3/dc8175a9cf6161a9096f64d610abb5a7ed48927456f407555c6a7479d6c8/ttlock_ble-0.3.0.tar.gz", hash = "sha256:ccc86e683c3feea30fa05fe2980800731eca4ed233c7c4e6434af629c913e88a", size = 55656, upload-time = "2026-08-30T02:03:25.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/73/afe017051116013e2f2ba1fdbdb6bee17a1646e44c277252f12c28badab9/ttlock_ble-0.2.2-py3-none-any.whl", hash = "sha256:d37263f50a035c0f0547c9a6cba1de64659388871610b664cd39f6c9130d6553", size = 65836, upload-time = "2026-08-26T19:46:33.844Z" },
+    { url = "https://files.pythonhosted.org/packages/44/8f/abb2a6ec2d45e03fc1007c14d195acda5cfe908c38444312153b42324c98/ttlock_ble-0.3.0-py3-none-any.whl", hash = "sha256:09f547eea90a96c1b20a8ee662126678884a633b240ef62ce4658f3e85702d89", size = 69986, upload-time = "2026-08-30T02:03:24.138Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves both pins that can drift — the `requirements` entry in `manifest.json` that HACS and Home Assistant install for end users, and the dev-group pin lint, mypy and pytest run against — and syncs the lockfile.

## What 0.3.0 brings

Three commands the lock had been rejecting outright for want of the CHECK_ADMIN handshake now work: keypad passcodes, the auto-lock delay, and writing the RTC. The auto-lock parser also stops reporting a genuine rejection as an unknown value, and `get_auto_lock_limits()` is new.

## Why this is a dependency move, not a behaviour change

None of those paths are reachable from this integration. It drives unlock/lock, the state and battery queries, the operation log, the sound switch and the device-info read — none of which changed in 0.3.0. The two breaking changes the release carries are likewise out of reach here:

- `get_auto_lock_time()` raises `TTLockError` on a rejection instead of answering `-1`.
- `calibrate_time()` and `sync_time()` require an explicit `local_time` reference where the argument was optional and defaulted to UTC.

Nothing in `custom_components/ttlock_ble/` calls auto-lock, passcode or clock commands.

## Verification

Lint, mypy and the full suite pass against the new pin (349 tests, 100% coverage). Confirmed against a running Home Assistant with the new pin installed: the config entry set up clean, and the lock, battery and last-seen entities kept reporting.
