### PR TITLE
feat: keep the lock's own clock aligned with local time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,10 @@ advertisement.py → decodes lock state + battery from the advertisements
 coordinator.py   → publishes the advertised state as it arrives; no polling
                     interval, a refresh only on demand
 lock.py          → LockEntity backed by the BLE connection
-sensor.py        → BatterySensor backed by the same poll + push events, and
-                    a LastSeenSensor reading the bluetooth manager's own
-                    advertisement history (see below)
+sensor.py        → BatterySensor backed by the same poll + push events, a
+                    LastSeenSensor reading the bluetooth manager's own
+                    advertisement history (see below), and a ClockDriftSensor
+                    reporting how far the lock's own clock has wandered
 binary_sensor.py → connectivity BinarySensorEntity reflecting live BLE link state
                     (named "Bluetooth connection": a healthy idle lock holds
                     no session, so this being off says nothing about reach)
@@ -76,6 +77,9 @@ device_description_store.py
                  → persists what each lock reported about itself (model,
                     hardware, firmware), so a restart shows it before any
                     session is opened
+clock_sync_store.py
+                 → persists when each lock's clock was last compared with
+                    local time, so the daily pacing survives a restart
 ```
 
 ### Entry typing
@@ -170,6 +174,15 @@ The diagnostics dump carries the last advertisement per lock, raw bytes included
 - **Once per Home Assistant run, not once ever.** The values are static until a firmware upgrade changes them, so the store is what a restart displays, and the first successful poll of each run re-reads and replaces it.
 - **An unknown field is left out of `device_info`, not spelled as `None`.** `DeviceInfo` is a TypedDict, and every key present is written to the registry device — `None` included, since only an absent key means "leave this alone". Spelling out an unknown version blanked what a poll had already stamped and reverted the model to the protocol fallback, on any entity re-registration before the store had an answer.
 - **The registry device is updated in place.** An entity's `device_info` is only read when the entity is registered, so a description learned mid-run would otherwise wait for the next restart to appear. A field the lock did not answer is left untouched rather than blanked — `entity.py` falls back to the key's protocol version for the model, which beats an empty one.
+
+### Clock alignment
+
+The lock stamps every operation-log record from an RTC it keeps itself: no NTP, no gateway, and no offset stored alongside the value. Home Assistant reads those stamps as local time, so a drifted clock files a whole day of door events at the wrong hour. `coordinator.py`'s `_async_align_clock` is what keeps them honest, and four things shape it:
+
+- **Nothing connects for it.** Like `_async_describe`, the comparison rides a session another read just opened — a poll that reached the lock, or an advertised operation-log read that landed. The log path is the one that matters on a mostly idle lock: every use of the door writes a record, and the read that follows is a session for free. It is deliberately in the `else` of that read's `try`, because a read that failed is no proof of a session and must not reach the retry bookkeeping in the `finally`.
+- **Once a day, paced from disk.** `clock_sync_store.py` keeps the timestamp per MAC. The answer moves by seconds a day, and holding the pacing only in memory would re-read on every restart.
+- **The reference is the midpoint of the read, and the write takes a fresh one.** A BLE round trip through a proxy costs seconds — enough that charging all of it to the lock reports a healthy clock as drifted by more than the SDK's 2 s default. `CLOCK_DRIFT_THRESHOLD_SECONDS` is 30 s for the same reason. This is also why `sync_time()` is not used: it captures its reference before the read and then writes that same, now stale, value.
+- **Reading is unauthenticated; writing is not.** `get_lock_time` needs no handshake, so a lock reached through a key with no admin password still reports its drift — the integration just cannot correct it. `TtlockBleClockDriftSensor` publishes the measured drift as a diagnostic, `unknown` until a session has carried a comparison.
 
 ### Lock entity
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Local control of TTLock smart locks over Bluetooth, for [Home Assistant](https:/
 - **Local BLE control** — lock, unlock, and state queries run over the lock's BLE link; the TTLock cloud is only contacted once at setup to download per-lock keys.
 - **Real-time push events** — keypad presses, fingerprint reads, IC-card swipes, mechanical key turns, and auto-lock fires arrive as Home Assistant events the moment the lock emits them.
 - **Battery sensor** — diagnostic entity refreshed by every poll *and* every push, no extra BLE traffic.
+- **Clock alignment** — the lock's own clock, which stamps every operation-log record, is compared against local time once a day on a session something else already opened, and corrected when it has wandered. A diagnostic sensor reports the measured drift.
 - **2FA-aware config flow** — handles TTLock's "new device" verification by emailing a one-time code and prompting for it.
 - **Works without a cloud account** — a lock initialised locally can be added by entering its key directly, no TTLock account involved at any point.
 - **Passive state tracking** — the bolt position and battery level are read from the lock's own BLE advertisements, with no connection and no battery cost. This is what catches an auto-lock or an operation done from the official app.
@@ -24,7 +25,7 @@ Local control of TTLock smart locks over Bluetooth, for [Home Assistant](https:/
 
 ## Entities
 
-Each configured lock produces one HA device, named with the model, hardware and firmware the lock reports about itself, carrying up to six entities:
+Each configured lock produces one HA device, named with the model, hardware and firmware the lock reports about itself, carrying up to seven entities:
 
 | Entity | Domain | Purpose |
 |---|---|---|
@@ -33,6 +34,7 @@ Each configured lock produces one HA device, named with the model, hardware and 
 | `binary_sensor.<alias>_bluetooth_connection` | `binary_sensor` | Whether a BLE session is open right now (connectivity, diagnostic). A healthy idle lock holds none, so `off` says nothing about whether the lock is reachable. |
 | `event.<alias>_log` | `event` | Fires for every new operation-log record read from the lock. |
 | `sensor.<alias>_last_seen` | `sensor` | When the lock was last heard from, read from HA's own advertisement history (diagnostic). |
+| `sensor.<alias>_clock_drift` | `sensor` | How far the lock's own clock was off local time when last compared, in seconds, positive when it runs ahead (diagnostic). `unknown` until a session opened for something else has carried a comparison. |
 | `switch.<alias>_sound` | `switch` | The lock's keypad/lock beep. Assumed state — the firmware reports no readback — and only created for an admin key that carries an admin passcode, which a manually entered key usually does not. |
 
 The event entity classifies each record as `unlock`, `lock`, `unlock_failed`, `password_change` or `other`, and attaches `record_type` and `battery` always, plus `timestamp`, `uid`, `credential`, `key_id` and `accessory_battery` when the record carries them. `credential` is only populated for record types where the value is an identifier (card number, fingerprint id, fob MAC) — record types where it would be a working door code never expose it.
@@ -127,8 +129,9 @@ custom_components/ttlock_ble/
 ├── manifest.json
 ├── manual_key.py      # TtlockBleManualKey: key entry for cloud-less locks
 ├── options_flow.py    # TtlockBleOptionsFlow: permanent_connection
+├── clock_sync_store.py # persisted clock comparison per lock
 ├── record_store.py    # persisted operation-log cursor per lock
-├── sensor.py          # TtlockBleBatterySensor + TtlockBleLastSeenSensor
+├── sensor.py          # battery, last-seen and clock-drift sensors
 ├── switch.py          # TtlockBleSoundSwitch: the lock's beep (admin keys only)
 └── translations/
     ├── en.json

--- a/custom_components/ttlock_ble/__init__.py
+++ b/custom_components/ttlock_ble/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.device_registry import (
 from ttlock_ble import VirtualKey
 
 from .advertisement import TtlockBleAdvertisementTracker
+from .clock_sync_store import async_get_clock_sync_store
 from .connection import TtlockBleConnection
 from .const import CONF_PERMANENT_CONNECTION, DOMAIN, LOGGER
 from .coordinator import TtlockBleDataUpdateCoordinator
@@ -123,10 +124,12 @@ async def async_setup_entry(
             await connection.async_start()
 
     description_store = await async_get_device_description_store(hass)
+    clock_sync_store = await async_get_clock_sync_store(hass)
     coordinator = TtlockBleDataUpdateCoordinator(
         hass=hass,
         connections=connections,
         descriptions=description_store,
+        clock_syncs=clock_sync_store,
     )
 
     bluetooth_unsubs = TtlockBleAdvertisementTracker(hass, coordinator).async_register(

--- a/custom_components/ttlock_ble/clock_sync_store.py
+++ b/custom_components/ttlock_ble/clock_sync_store.py
@@ -1,0 +1,81 @@
+"""Persisted per-lock record of when its clock was last checked."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.singleton import singleton
+from homeassistant.helpers.storage import Store
+from homeassistant.util.hass_dict import HassKey
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .data import TtlockBleClockSync
+
+STORAGE_VERSION = 1
+STORAGE_KEY = f"{DOMAIN}.clock_syncs"
+SAVE_DELAY_SECONDS = 10
+
+
+class TtlockBleClockSyncStore:
+    """
+    Remember when each lock's clock was last compared against local time.
+
+    The comparison rides on a session another read already opened, but
+    the decision to run it is paced in days. Holding that timestamp only
+    in memory would restart the pacing on every Home Assistant restart,
+    and a lock that is reachable often would then be read on every one
+    of them for an answer that moves by seconds a week.
+
+    Keyed by MAC rather than by entry, for the same reason the device
+    descriptions are: a lock keeps its history across a reconfigure, and
+    a cloud entry and a manual entry describing the same lock agree.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Bind the records to HA's storage helper."""
+        self._store: Store[dict[str, TtlockBleClockSync]] = Store(
+            hass,
+            STORAGE_VERSION,
+            STORAGE_KEY,
+        )
+        self._syncs: dict[str, TtlockBleClockSync] = {}
+
+    async def async_load(self) -> None:
+        """Read the persisted records, tolerating a missing or empty file."""
+        data = await self._store.async_load()
+        if not data:
+            return
+        self._syncs = dict(data)
+
+    def get(self, mac: str) -> TtlockBleClockSync | None:
+        """Return the last clock comparison for `mac`, if there was one."""
+        return self._syncs.get(mac)
+
+    def async_remember(self, mac: str, sync: TtlockBleClockSync) -> None:
+        """Persist a comparison for `mac`, replacing any earlier one."""
+        self._syncs[mac] = sync
+        self._store.async_delay_save(self._snapshot, SAVE_DELAY_SECONDS)
+
+    def _snapshot(self) -> dict[str, TtlockBleClockSync]:
+        """Render the in-memory records as the JSON the store writes."""
+        return dict(self._syncs)
+
+
+STORE_KEY: HassKey[TtlockBleClockSyncStore] = HassKey(f"{DOMAIN}_clock_sync_store")
+
+
+@singleton(STORE_KEY, async_=True)
+async def async_get_clock_sync_store(hass: HomeAssistant) -> TtlockBleClockSyncStore:
+    """
+    Return the one store this Home Assistant instance shares.
+
+    One instance per entry writes the whole file from what it loaded, so
+    two entries would take turns dropping each other's newer records.
+    """
+    store = TtlockBleClockSyncStore(hass)
+    await store.async_load()
+    return store

--- a/custom_components/ttlock_ble/connection.py
+++ b/custom_components/ttlock_ble/connection.py
@@ -27,6 +27,8 @@ from .const import DOMAIN, LOGGER
 from .data import TtlockBleLogCursor
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from bleak import BleakClient
     from homeassistant.core import HomeAssistant
 
@@ -184,6 +186,61 @@ class TtlockBleConnection:
                     exc,
                 )
                 return None
+
+    async def async_get_lock_time(self) -> datetime | None:
+        """
+        Read the lock's own clock through the connection.
+
+        Returns `None` when the lock is out of range or the read failed.
+        The value is naive and carries no offset: it is whatever wall
+        clock was last written to the lock, which for a lock set up by
+        the official app is local time.
+
+        No admin handshake is involved - the firmware answers this one
+        unauthenticated, unlike `async_calibrate_time`.
+        """
+        async with self._lock:
+            client = await self._async_ensure_connected_locked()
+            if client is None:
+                return None
+            try:
+                return await client.get_lock_time()
+            except Exception as exc:  # noqa: BLE001
+                # A clock reading is not worth losing a poll over: the
+                # caller keeps whatever it knew and tries again later.
+                LOGGER.debug(
+                    "get_lock_time failed for %s: %s",
+                    self._key.lockMac,
+                    exc,
+                )
+                return None
+
+    async def async_calibrate_time(self, local_time: datetime) -> bool:
+        """
+        Write `local_time` to the lock's clock. Reports whether it landed.
+
+        `local_time` is stored verbatim, with no offset attached, and is
+        what the lock reports back in every operation-log record - so it
+        has to be the wall clock the records are meant to read in, not
+        UTC.
+
+        Admin-gated by the firmware, so a key carrying no admin password
+        can only ever fail here; callers check that before asking.
+        """
+        async with self._lock:
+            client = await self._async_ensure_connected_locked()
+            if client is None:
+                return False
+            try:
+                await client.calibrate_time(local_time)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.debug(
+                    "calibrate_time failed for %s: %s",
+                    self._key.lockMac,
+                    exc,
+                )
+                return False
+            return True
 
     async def async_lock(self) -> None:
         """Send a LOCK command on the live connection (raises on failure)."""

--- a/custom_components/ttlock_ble/coordinator.py
+++ b/custom_components/ttlock_ble/coordinator.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from ttlock_ble import LockState
 
@@ -38,8 +39,10 @@ if TYPE_CHECKING:
 
     from ttlock_ble import LockAdvertisement
 
+    from .clock_sync_store import TtlockBleClockSyncStore
     from .connection import TtlockBleConnection
     from .data import (
+        TtlockBleClockSync,
         TtlockBleConfigEntry,
         TtlockBleCoordinatorData,
         TtlockBleDeviceDescription,
@@ -62,6 +65,23 @@ LOG_RETRY_COOLDOWN_SECONDS = 300.0
 # is not connected to on every advertisement it sends.
 STATE_PROBE_COOLDOWN_SECONDS = 300.0
 
+# How long between comparisons of a lock's clock against local time. The
+# lock has no NTP and drifts by seconds a day, so checking more often
+# than this spends a BLE round trip to learn nothing.
+CLOCK_CHECK_INTERVAL_SECONDS = 24 * 60 * 60
+
+# How far off the lock's clock has to read before it is written back.
+# Deliberately far above the two seconds the library defaults to: the
+# measurement travels over BLE, and the round trip alone accounts for
+# seconds, so a tighter threshold would rewrite a healthy lock's clock
+# on every check and pay for it in battery.
+CLOCK_DRIFT_THRESHOLD_SECONDS = 30.0
+
+# Above this, a correction is worth a line in the log at INFO. A lock
+# does not drift by minutes on its own - a gap that size usually means
+# it was set up on a different wall clock than Home Assistant keeps.
+CLOCK_LARGE_CORRECTION_SECONDS = 300.0
+
 
 class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinatorData"]):
     """Publish lock state, from advertisements and from on-demand reads."""
@@ -73,6 +93,7 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
         hass: HomeAssistant,
         connections: dict[str, TtlockBleConnection],
         descriptions: TtlockBleDeviceDescriptionStore,
+        clock_syncs: TtlockBleClockSyncStore,
     ) -> None:
         """
         Pin the per-MAC connection map. No polling interval on purpose.
@@ -87,6 +108,7 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
         super().__init__(hass=hass, logger=LOGGER, name=DOMAIN)
         self._connections = connections
         self._descriptions = descriptions
+        self._clock_syncs = clock_syncs
         self._described: set[str] = set()
         self._log_fetches: set[str] = set()
         self._records_pending: dict[str, bool] = {}
@@ -123,6 +145,11 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
     def async_device_description(self, mac: str) -> TtlockBleDeviceDescription | None:
         """Return the hardware strings `mac` last reported about itself."""
         return self._descriptions.get(mac)
+
+    @callback
+    def async_clock_sync(self, mac: str) -> TtlockBleClockSync | None:
+        """Return the last clock comparison for `mac`, if there was one."""
+        return self._clock_syncs.get(mac)
 
     @callback
     def async_has_state(self, mac: str) -> bool:
@@ -333,6 +360,12 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
                 mac,
                 exc_info=True,
             )
+        else:
+            # Only once the read landed: it is proof of a live session,
+            # which is the whole reason the clock check rides here. A
+            # failure above must not reach the retry bookkeeping below
+            # as if the log itself had failed.
+            await self._async_align_clock(connection)
         finally:
             self._log_fetches.discard(mac)
             if self._records_pending.get(mac, False):
@@ -377,6 +410,7 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
                 exc_info=True,
             )
         await self._async_describe(connection)
+        await self._async_align_clock(connection)
         return {
             "locked": _parse_lock_state(raw_state),
             "battery_level": battery,
@@ -408,6 +442,91 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
             return
         self._descriptions.async_remember(mac, description)
         self._async_apply_description(mac, description)
+
+    async def _async_align_clock(self, connection: TtlockBleConnection) -> None:
+        """
+        Compare the lock's clock against local time, and correct a drifted one.
+
+        Rides on a session another read just opened, like the hardware
+        description does, and runs at most once a day per lock: the
+        answer moves by seconds a day, and a lock only grants a session
+        while it is awake.
+
+        The comparison is what makes the lock's operation-log records
+        trustworthy. Every record is stamped from this clock, with no
+        offset attached, and Home Assistant reads those stamps as local
+        time - so a lock whose clock has wandered files the door events
+        of a whole day at the wrong hour.
+        """
+        mac = connection.key.lockMac
+        if not self._async_clock_check_due(mac):
+            return
+        before = dt_util.now()
+        lock_time = await connection.async_get_lock_time()
+        if lock_time is None:
+            return
+        # The reference is the midpoint of the read, not its start: the
+        # round trip takes seconds over BLE, and charging all of that to
+        # the lock would report a healthy clock as drifted.
+        reference = before + (dt_util.now() - before) / 2
+        drift = (lock_time - reference.replace(tzinfo=None)).total_seconds()
+        LOGGER.debug("Clock drift for %s: %+.1fs", mac, drift)
+        self._clock_syncs.async_remember(
+            mac,
+            {"checked_at": dt_util.utcnow().isoformat(), "drift_seconds": drift},
+        )
+        self.async_update_listeners()
+        if abs(drift) <= CLOCK_DRIFT_THRESHOLD_SECONDS:
+            return
+        await self._async_correct_clock(connection, drift)
+
+    async def _async_correct_clock(
+        self,
+        connection: TtlockBleConnection,
+        drift: float,
+    ) -> None:
+        """
+        Write local time back to a lock whose clock has wandered.
+
+        The reference is taken here rather than reused from the
+        comparison: that one is already a round trip old by now, and
+        writing it would put the lock behind by exactly the delay the
+        check was measuring.
+
+        Only a key carrying an admin password can do this - the firmware
+        gates the write behind CHECK_ADMIN. A lock read through a key
+        without one still gets its drift reported; there is just nothing
+        this integration can do about it.
+        """
+        mac = connection.key.lockMac
+        if not connection.key.adminPs.isdigit():
+            LOGGER.debug(
+                "Clock of %s is %+.1fs off, but its key carries no admin password",
+                mac,
+                drift,
+            )
+            return
+        if abs(drift) > CLOCK_LARGE_CORRECTION_SECONDS:
+            LOGGER.info(
+                "Clock of %s was %+.1fs off local time, correcting it",
+                mac,
+                drift,
+            )
+        if not await connection.async_calibrate_time(
+            dt_util.now().replace(tzinfo=None)
+        ):
+            LOGGER.debug("Clock correction did not reach %s", mac)
+
+    def _async_clock_check_due(self, mac: str) -> bool:
+        """Report whether `mac` is due for a clock comparison."""
+        last = self._clock_syncs.get(mac)
+        if last is None:
+            return True
+        checked_at = dt_util.parse_datetime(last["checked_at"])
+        if checked_at is None:
+            return True
+        age = (dt_util.utcnow() - checked_at).total_seconds()
+        return age >= CLOCK_CHECK_INTERVAL_SECONDS
 
     @callback
     def _async_apply_description(

--- a/custom_components/ttlock_ble/data/__init__.py
+++ b/custom_components/ttlock_ble/data/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from .clock_sync import TtlockBleClockSync
 from .config_data import TtlockBleConfigData
 from .credentials_input import TtlockBleCredentialsInput
 from .device_description import TtlockBleDeviceDescription
@@ -36,6 +37,7 @@ type TtlockBleCoordinatorData = dict[str, TtlockBleLockState]
 
 
 __all__ = [
+    "TtlockBleClockSync",
     "TtlockBleConfigData",
     "TtlockBleConfigEntry",
     "TtlockBleCoordinatorData",

--- a/custom_components/ttlock_ble/data/clock_sync.py
+++ b/custom_components/ttlock_ble/data/clock_sync.py
@@ -1,0 +1,24 @@
+"""What the last comparison of a lock's clock against Home Assistant's found."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class TtlockBleClockSync(TypedDict):
+    """
+    Outcome of the last comparison between a lock's RTC and local time.
+
+    `drift_seconds` is what the lock was off by *before* any correction,
+    positive when it ran ahead. It is kept as measured rather than reset
+    to zero after a calibration, because the useful question is how far
+    the clock had wandered — a lock that needs a minute put back on it
+    every day is a lock whose records are worth doubting.
+
+    `checked_at` is when the comparison ran, not when a correction was
+    written: a lock whose clock was already close is checked and left
+    alone, and that still counts as knowing where it stands.
+    """
+
+    checked_at: str
+    drift_seconds: float

--- a/custom_components/ttlock_ble/sensor.py
+++ b/custom_components/ttlock_ble/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for ttlock_ble — battery level and last contact."""
+"""Sensor platform for ttlock_ble — battery level, last contact and clock drift."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTime
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import async_track_time_interval
@@ -52,6 +52,7 @@ async def async_setup_entry(
         for sensor in (
             TtlockBleBatterySensor(data.coordinator, key),
             TtlockBleLastSeenSensor(data.coordinator, key),
+            TtlockBleClockDriftSensor(data.coordinator, key),
         )
     )
 
@@ -114,6 +115,48 @@ class TtlockBleBatterySensor(TtlockBleEntity, SensorEntity):
         if battery is None:
             return
         self._attr_native_value = battery
+
+
+class TtlockBleClockDriftSensor(TtlockBleEntity, SensorEntity):
+    """
+    How far the lock's own clock was off local time when last compared.
+
+    The lock stamps every operation-log record from a clock it keeps
+    itself, with no NTP and no offset attached, and Home Assistant reads
+    those stamps as local time. A drifted clock therefore files a whole
+    day of door events at the wrong hour, and nothing else on the device
+    would show it.
+
+    Positive means the lock runs ahead. The value is what was measured
+    before any correction, so it stays a reading of how far the clock
+    wanders rather than resetting to zero every time one is written
+    back. It reports `unknown` until a session opened for something else
+    has carried a comparison — nothing here connects for it.
+    """
+
+    _attr_translation_key = "clock_drift"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_suggested_display_precision = 1
+
+    @property
+    def unique_id(self) -> str:
+        """Return a stable unique id for this entity."""
+        return f"{self._key.lockMac}_clock_drift"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the drift of the last comparison, if one has run."""
+        sync = self.coordinator.async_clock_sync(self._key.lockMac)
+        return None if sync is None else sync["drift_seconds"]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Carry when the comparison ran, so a stale reading reads as stale."""
+        sync = self.coordinator.async_clock_sync(self._key.lockMac)
+        return None if sync is None else {"checked_at": sync["checked_at"]}
 
 
 class TtlockBleLastSeenSensor(TtlockBleEntity, SensorEntity):

--- a/custom_components/ttlock_ble/translations/en.json
+++ b/custom_components/ttlock_ble/translations/en.json
@@ -137,6 +137,9 @@
       "battery": {
         "name": "Battery"
       },
+      "clock_drift": {
+        "name": "Clock drift"
+      },
       "last_seen": {
         "name": "Last seen"
       }

--- a/custom_components/ttlock_ble/translations/pt-BR.json
+++ b/custom_components/ttlock_ble/translations/pt-BR.json
@@ -137,6 +137,9 @@
       "battery": {
         "name": "Bateria"
       },
+      "clock_drift": {
+        "name": "Desvio do relógio"
+      },
       "last_seen": {
         "name": "Visto por último"
       }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,8 @@ def mock_ttlock_connection() -> Generator[MagicMock]:
     instance.async_query_state = AsyncMock(return_value=(0, 80))
     instance.async_get_operation_log = AsyncMock(return_value=[])
     instance.async_get_device_info = AsyncMock(return_value=None)
+    instance.async_get_lock_time = AsyncMock(return_value=None)
+    instance.async_calibrate_time = AsyncMock(return_value=True)
     instance.async_lock = AsyncMock(return_value=None)
     instance.async_unlock = AsyncMock(return_value=None)
     instance.async_set_lock_sound = AsyncMock(return_value=None)

--- a/tests/test_clock_sync_store.py
+++ b/tests/test_clock_sync_store.py
@@ -1,0 +1,61 @@
+"""Coverage for the persisted per-lock clock comparison."""
+
+from __future__ import annotations
+
+from custom_components.ttlock_ble.clock_sync_store import (
+    STORAGE_KEY,
+    STORAGE_VERSION,
+    TtlockBleClockSyncStore,
+)
+
+MAC = "AA:BB:CC:DD:EE:FF"
+SYNC = {"checked_at": "2026-08-29T22:00:00+00:00", "drift_seconds": -1.5}
+
+
+async def test_load_tolerates_a_missing_file(hass) -> None:
+    store = TtlockBleClockSyncStore(hass)
+    await store.async_load()
+    assert store.get(MAC) is None
+
+
+async def test_load_restores_the_persisted_record(hass, hass_storage) -> None:
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {MAC: SYNC},
+    }
+    store = TtlockBleClockSyncStore(hass)
+    await store.async_load()
+    assert store.get(MAC) == SYNC
+
+
+async def test_remember_replaces_the_earlier_record(hass) -> None:
+    store = TtlockBleClockSyncStore(hass)
+    store.async_remember(MAC, SYNC)
+    later = {"checked_at": "2026-08-30T22:00:00+00:00", "drift_seconds": 42.0}
+    store.async_remember(MAC, later)
+    assert store.get(MAC) == later
+
+
+async def test_remember_writes_the_delayed_snapshot(hass, hass_storage) -> None:
+    store = TtlockBleClockSyncStore(hass)
+    store.async_remember(MAC, SYNC)
+    await store._store.async_save(store._snapshot())
+    assert hass_storage[STORAGE_KEY]["data"] == {MAC: SYNC}
+
+
+async def test_locks_keep_separate_records(hass) -> None:
+    store = TtlockBleClockSyncStore(hass)
+    store.async_remember(MAC, SYNC)
+    assert store.get("11:22:33:44:55:66") is None
+
+
+async def test_every_entry_shares_one_store(hass) -> None:
+    """Two instances over one storage key take turns dropping each other's writes."""
+    from custom_components.ttlock_ble.clock_sync_store import async_get_clock_sync_store
+
+    first = await async_get_clock_sync_store(hass)
+    first.async_remember(MAC, SYNC)
+    second = await async_get_clock_sync_store(hass)
+
+    assert second is first
+    assert second.get(MAC) == SYNC

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -759,6 +760,80 @@ async def test_device_info_that_breaks_the_link_costs_nothing_else(
     mock_ttlock_client.get_device_info = AsyncMock(side_effect=TTLockError("link down"))
     conn = TtlockBleConnection(hass, sample_virtual_key)
     assert await conn.async_get_device_info() is None
+
+
+async def test_get_lock_time_returns_the_lock_rtc(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    when = dt.datetime(2026, 8, 29, 22, 43, 10)  # noqa: DTZ001
+    mock_ttlock_client.get_lock_time = AsyncMock(return_value=when)
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_get_lock_time() == when
+
+
+async def test_get_lock_time_returns_none_when_device_missing(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    mock_ble_resolver.return_value = None
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_get_lock_time() is None
+    mock_ttlock_client.connect.assert_not_awaited()
+
+
+async def test_get_lock_time_that_fails_costs_nothing_else(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    """A clock reading is not worth failing the poll that carried it."""
+    mock_ttlock_client.get_lock_time = AsyncMock(side_effect=TTLockError("link down"))
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_get_lock_time() is None
+
+
+async def test_calibrate_time_reports_that_it_landed(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    when = dt.datetime(2026, 8, 29, 22, 43, 10)  # noqa: DTZ001
+    mock_ttlock_client.calibrate_time = AsyncMock(return_value=None)
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_calibrate_time(when) is True
+    mock_ttlock_client.calibrate_time.assert_awaited_once_with(when)
+
+
+async def test_calibrate_time_reports_a_lock_out_of_reach(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    mock_ble_resolver.return_value = None
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_calibrate_time(dt.datetime(2026, 8, 29)) is False  # noqa: DTZ001
+
+
+async def test_calibrate_time_reports_a_rejection(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    """A key with no admin password is refused by the firmware, not by us."""
+    mock_ttlock_client.calibrate_time = AsyncMock(
+        side_effect=TTLockError("Failed to authorize as admin")
+    )
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_calibrate_time(dt.datetime(2026, 8, 29)) is False  # noqa: DTZ001
 
 
 async def test_a_bleak_error_from_connect_is_not_left_raw(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import datetime as dt
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.util import dt as dt_util
 from ttlock_ble import DeviceInfo
 
+from custom_components.ttlock_ble.clock_sync_store import TtlockBleClockSyncStore
 from custom_components.ttlock_ble.coordinator import (
+    CLOCK_CHECK_INTERVAL_SECONDS,
+    CLOCK_DRIFT_THRESHOLD_SECONDS,
     TtlockBleDataUpdateCoordinator,
     _parse_lock_state,
 )
@@ -34,14 +39,17 @@ def _mock_connection(*, query_return=(0, 80), mac="AA:BB:CC:DD:EE:FF") -> MagicM
     conn.async_query_state = AsyncMock(return_value=query_return)
     conn.async_get_operation_log = AsyncMock(return_value=[])
     conn.async_get_device_info = AsyncMock(return_value=None)
+    conn.async_get_lock_time = AsyncMock(return_value=None)
+    conn.async_calibrate_time = AsyncMock(return_value=True)
     return conn
 
 
-def _coordinator(hass, connections, descriptions=None):
+def _coordinator(hass, connections, descriptions=None, clock_syncs=None):
     return TtlockBleDataUpdateCoordinator(
         hass=hass,
         connections=connections,
         descriptions=descriptions or TtlockBleDeviceDescriptionStore(hass),
+        clock_syncs=clock_syncs or TtlockBleClockSyncStore(hass),
     )
 
 
@@ -673,3 +681,141 @@ async def test_a_cancelled_retry_never_fires_again(hass) -> None:
     await hass.async_block_till_done()
 
     conn.async_get_operation_log.assert_not_awaited()
+
+
+MAC = "AA:BB:CC:DD:EE:FF"
+
+
+def _clock_connection(*, lock_offset_seconds: float, admin_ps: str = "135792468"):
+    """A connection whose lock answers a clock `lock_offset_seconds` off local time."""
+    conn = _mock_connection()
+    conn.key = MagicMock(lockMac=MAC, adminPs=admin_ps)
+    naive_now = dt_util.now().replace(tzinfo=None)
+    conn.async_get_lock_time = AsyncMock(
+        return_value=naive_now + dt.timedelta(seconds=lock_offset_seconds)
+    )
+    conn.async_calibrate_time = AsyncMock(return_value=True)
+    return conn
+
+
+async def test_a_healthy_clock_is_measured_and_left_alone(hass) -> None:
+    """Within the threshold there is nothing to write, and writing costs battery."""
+    conn = _clock_connection(lock_offset_seconds=1.0)
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    conn.async_get_lock_time.assert_awaited_once()
+    conn.async_calibrate_time.assert_not_awaited()
+    sync = coordinator.async_clock_sync(MAC)
+    assert sync is not None
+    assert abs(sync["drift_seconds"]) < CLOCK_DRIFT_THRESHOLD_SECONDS
+
+
+async def test_a_drifted_clock_is_corrected(hass) -> None:
+    conn = _clock_connection(lock_offset_seconds=-600.0)
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    conn.async_calibrate_time.assert_awaited_once()
+    written = conn.async_calibrate_time.await_args.args[0]
+    assert written.tzinfo is None
+    # Written from a reference taken at the write, not the stale one the
+    # comparison used - reusing that would put the lock a round trip behind.
+    assert abs((written - dt_util.now().replace(tzinfo=None)).total_seconds()) < 5
+    assert (
+        coordinator.async_clock_sync(MAC)["drift_seconds"]
+        < -CLOCK_DRIFT_THRESHOLD_SECONDS
+    )
+
+
+async def test_a_key_with_no_admin_password_still_reports_its_drift(hass) -> None:
+    """The read is unauthenticated; only the correction needs an admin password."""
+    conn = _clock_connection(lock_offset_seconds=-600.0, admin_ps="")
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    conn.async_calibrate_time.assert_not_awaited()
+    assert coordinator.async_clock_sync(MAC) is not None
+
+
+async def test_an_unreachable_clock_records_nothing(hass) -> None:
+    """A failed read must not stamp a check that never happened."""
+    conn = _clock_connection(lock_offset_seconds=0.0)
+    conn.async_get_lock_time = AsyncMock(return_value=None)
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    assert coordinator.async_clock_sync(MAC) is None
+    conn.async_calibrate_time.assert_not_awaited()
+
+
+async def test_the_clock_is_checked_at_most_once_a_day(hass) -> None:
+    conn = _clock_connection(lock_offset_seconds=1.0)
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+
+    conn.async_get_lock_time.assert_awaited_once()
+
+
+async def test_the_clock_is_checked_again_once_the_interval_has_passed(hass) -> None:
+    conn = _clock_connection(lock_offset_seconds=1.0)
+    clock_syncs = TtlockBleClockSyncStore(hass)
+    stale = dt_util.utcnow() - dt.timedelta(seconds=CLOCK_CHECK_INTERVAL_SECONDS + 60)
+    clock_syncs.async_remember(
+        MAC,
+        {"checked_at": stale.isoformat(), "drift_seconds": 0.0},
+    )
+    coordinator = _coordinator(hass, {MAC: conn}, clock_syncs=clock_syncs)
+
+    await coordinator._async_update_data()
+
+    conn.async_get_lock_time.assert_awaited_once()
+
+
+async def test_an_unreadable_stored_timestamp_is_treated_as_never_checked(hass) -> None:
+    """A record that cannot be parsed must not wedge the check off forever."""
+    conn = _clock_connection(lock_offset_seconds=1.0)
+    clock_syncs = TtlockBleClockSyncStore(hass)
+    clock_syncs.async_remember(MAC, {"checked_at": "not a date", "drift_seconds": 0.0})
+    coordinator = _coordinator(hass, {MAC: conn}, clock_syncs=clock_syncs)
+
+    await coordinator._async_update_data()
+
+    conn.async_get_lock_time.assert_awaited_once()
+
+
+async def test_a_correction_that_never_reaches_the_lock_is_survivable(hass) -> None:
+    conn = _clock_connection(lock_offset_seconds=-600.0)
+    conn.async_calibrate_time = AsyncMock(return_value=False)
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    conn.async_calibrate_time.assert_awaited_once()
+
+
+async def test_the_log_read_carries_the_clock_check(hass) -> None:
+    """An advertised log read is the session a mostly idle lock actually grants."""
+    conn = _clock_connection(lock_offset_seconds=1.0)
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_fetch_operation_log(MAC, conn)
+
+    conn.async_get_lock_time.assert_awaited_once()
+
+
+async def test_a_failed_log_read_carries_no_clock_check(hass) -> None:
+    """A read that never landed is no proof of a session to ride on."""
+    conn = _clock_connection(lock_offset_seconds=1.0)
+    conn.async_get_operation_log = AsyncMock(side_effect=ValueError("garbled frame"))
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_fetch_operation_log(MAC, conn)
+
+    conn.async_get_lock_time.assert_not_awaited()

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, format_mac
 
+from custom_components.ttlock_ble.clock_sync_store import TtlockBleClockSyncStore
 from custom_components.ttlock_ble.const import DOMAIN, MANUFACTURER
 from custom_components.ttlock_ble.coordinator import TtlockBleDataUpdateCoordinator
 from custom_components.ttlock_ble.device_description_store import (
@@ -18,6 +19,7 @@ def _entity(hass, key, description=None) -> TtlockBleEntity:
         hass=hass,
         connections={},
         descriptions=descriptions,
+        clock_syncs=TtlockBleClockSyncStore(hass),
     )
     return TtlockBleEntity(coordinator, key)
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -660,6 +660,7 @@ def test_lock_sync_from_coordinator_no_snapshot_keeps_state(
     """An empty coordinator snapshot leaves `_attr_is_locked` untouched."""
     from unittest.mock import MagicMock
 
+    from custom_components.ttlock_ble.clock_sync_store import TtlockBleClockSyncStore
     from custom_components.ttlock_ble.coordinator import TtlockBleDataUpdateCoordinator
     from custom_components.ttlock_ble.device_description_store import (
         TtlockBleDeviceDescriptionStore,
@@ -670,6 +671,7 @@ def test_lock_sync_from_coordinator_no_snapshot_keeps_state(
         hass,
         {},
         TtlockBleDeviceDescriptionStore(hass),
+        TtlockBleClockSyncStore(hass),
     )
     coordinator.data = {}
     entity = TtlockBleLock(coordinator, sample_virtual_key, MagicMock())

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -21,8 +21,45 @@ def _last_seen_state(hass):
     )
 
 
+def _clock_drift_state(hass):
+    """The clock-drift sensor."""
+    return next(
+        state
+        for state in hass.states.async_all("sensor")
+        if state.attributes.get("device_class") == "duration"
+    )
+
+
+async def test_clock_drift_is_unknown_until_a_session_carried_a_comparison(
+    hass,
+    setup_integration,
+) -> None:
+    """Nothing here connects for it, so before the first check there is no answer."""
+    assert _clock_drift_state(hass).state == "unknown"
+
+
+async def test_clock_drift_reports_the_last_comparison(
+    hass,
+    setup_integration,
+    sample_virtual_key,
+) -> None:
+    from custom_components.ttlock_ble.clock_sync_store import async_get_clock_sync_store
+
+    store = await async_get_clock_sync_store(hass)
+    store.async_remember(
+        sample_virtual_key.lockMac,
+        {"checked_at": "2026-08-29T22:00:00+00:00", "drift_seconds": -12.5},
+    )
+    setup_integration.runtime_data.coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+
+    state = _clock_drift_state(hass)
+    assert float(state.state) == -12.5
+    assert state.attributes["checked_at"] == "2026-08-29T22:00:00+00:00"
+
+
 async def test_battery_sensor_created_for_each_key(hass, setup_integration) -> None:
-    assert len(hass.states.async_all("sensor")) == 2
+    assert len(hass.states.async_all("sensor")) == 3
 
 
 async def test_battery_sensor_reports_coordinator_value(
@@ -150,6 +187,7 @@ def test_battery_sync_from_coordinator_no_snapshot_keeps_value(
 ) -> None:
     """An empty coordinator snapshot leaves `_attr_native_value` untouched."""
 
+    from custom_components.ttlock_ble.clock_sync_store import TtlockBleClockSyncStore
     from custom_components.ttlock_ble.coordinator import TtlockBleDataUpdateCoordinator
     from custom_components.ttlock_ble.device_description_store import (
         TtlockBleDeviceDescriptionStore,
@@ -160,6 +198,7 @@ def test_battery_sync_from_coordinator_no_snapshot_keeps_value(
         hass,
         {},
         TtlockBleDeviceDescriptionStore(hass),
+        TtlockBleClockSyncStore(hass),
     )
     coordinator.data = {}
     entity = TtlockBleBatterySensor(coordinator, sample_virtual_key)


### PR DESCRIPTION
Every operation-log record is stamped from a clock the lock keeps itself: no NTP, no gateway, and no offset stored beside the value. Home Assistant reads those stamps as local time, so a clock that has wandered files a whole day of door events at the wrong hour — and nothing on the device would have shown it.

## How it works

The comparison rides a session another read has already opened — a poll that reached the lock, or an advertised operation-log read that landed. On a lock in daily use the second is the frequent one: every use of the door writes a record, and the read that follows is a session for free. **Nothing connects for this.**

- **Once a day per lock**, paced from a store keyed by MAC so a restart does not restart the pacing.
- **Corrected past thirty seconds of drift**, far above the two seconds the library defaults to. The measurement travels over BLE and the round trip alone accounts for seconds, so a tighter threshold would rewrite a healthy lock's clock on every check and spend its battery doing it.
- **The reference is the midpoint of the read**, not its start, and the correction takes a fresh one rather than reusing what the comparison measured against. That is also why `sync_time()` is not used here — it writes the stale reference.
- **Reading needs no admin handshake.** A lock reached through a key with no admin password still reports its drift; only the correction is skipped.

## New entity

`sensor.<alias>_clock_drift` — a diagnostic sensor carrying the drift in seconds, positive when the lock runs ahead, with the time of the comparison as an attribute. It reports `unknown` until a session opened for something else has carried one. The value is what was measured *before* any correction, so it stays a reading of how far the clock wanders rather than resetting to zero each time one is written back.

## Verified on hardware

Against the running integration and a physical lock, in order:

| step | result |
| --- | --- |
| first comparison, clock healthy | measured `-4.3s`, below threshold, nothing written |
| clock pushed 198s out on purpose | detected on the next session as `-198.1s` |
| correction | accepted by the lock, written **305 ms** after the read, on the session already open |
| following comparison | `-1.9s` — converged, nothing written |
| Home Assistant restarted | the sensor came back with the stored reading, which is what the daily pacing depends on |

Lint, mypy and the suite pass: 373 tests, 100% coverage.
