### PR TITLE
feat: discover locks over bluetooth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,11 +93,25 @@ The two stores are the deliberate exception: `record_store.py` and `device_descr
 `config_flow.py` implements the user-facing steps, sharing one module-level `_credentials_schema` builder for the credential ones and one `_manual_key_schema` for the manual one:
 
 - `async_step_user` — a menu, nothing else: the entry can come from a cloud account or from a key entered by hand.
+- `async_step_bluetooth` / `async_step_bluetooth_confirm` — the discovery entry point (see below); the confirm step is the same two-option menu, with the lock already identified.
 - `async_step_cloud` — the credential step (named `user` before the menu existed); sets unique_id from username, aborts on duplicate. Branches to `async_step_verify_code` when the cloud rejects the login with the 2FA "new device" error code.
 - `async_step_verify_code` — second step of the 2FA branch; submits the emailed code via `_async_validate_code_and_login` and finalizes entry creation on success.
 - `async_step_reauth` / `async_step_reauth_confirm` — HA's reauth entry points. Nothing in this integration currently raises `ConfigEntryAuthFailed` to trigger them automatically — the coordinator and `connection.py` only ever talk BLE after setup, never the cloud again — so today these steps are reachable only by manually starting a reauth flow for the entry. `async_update_reload_and_abort` rotates credentials in place on success.
 - `async_step_manual` — takes a key obtained outside the cloud (see below); unique_id is the lock's MAC.
 - `async_step_reconfigure` — lets the user edit credentials via the integration's three-dot menu, no delete-and-re-add cycle. **Branches on how the entry was created**: an entry with no `username` has no account to re-prompt for, so it goes to `async_step_reconfigure_manual` and re-opens the key form pre-filled instead.
+
+### Bluetooth discovery
+
+`manifest.json` carries one matcher, `manufacturer_id: 773` with `connectable: false`. 773 is `0x0305`: bleak splits the two leading bytes of the manufacturer data off as the company id, and on a V3 lock those bytes are the protocol type and version themselves. `connectable: false` is what lets a lock heard only through a non-connectable proxy still raise the flow. `loader.py`'s `async_get_bluetooth` reads custom integrations' manifests, so no core-side registration is involved.
+
+Four things shape the flow:
+
+- **The matcher is deliberately broad and the flow is what narrows it.** A manufacturer id is not proof of anything, so `async_step_bluetooth` runs `decode_lock_advertisement` and aborts with `not_a_lock` unless the payload decodes *and* the address it carries matches the one it was heard from — the same cross-check the tracker applies, which is why that decoder is now a module-level function in `advertisement.py` shared by the tracker, the manual key form and the flow.
+- **Both collision checks run.** `_abort_if_unique_id_configured` catches a manual entry, whose unique id is the MAC; `_abort_if_lock_configured` catches a cloud entry, whose unique id is the account. Without the second, a lock already managed through an account would keep offering itself as a new discovery.
+- **Discovery never completes an entry on its own.** The advertisement carries the address and the frame header, never the AES and unlock keys — those exist only in a TTLock account or in whatever provisioned the lock locally. So the confirm step is the ordinary menu, and the manual form is pre-filled from the advertisement (`_discovered_defaults`), which also removes the class of typo the header cross-check exists to catch.
+- **The cloud branch is bound to the lock that was found.** `_discovered_lock_missing_from` rejects an account whose key set does not contain the discovered MAC, because the flow was started from a card naming one lock: creating an entry for a different set of locks and leaving that one unconfigured is not what the user asked for. Started from `async_step_user` there is no discovery, and the check is inert.
+
+Locks older than the 5.3 header are out of reach here — that branch of the decoder reads the protocol type at `raw[4]` under a company id we have no sample of — and they stay on the manual entry point. A TTLock belonging to somebody else, in range, also raises a discovery card; Home Assistant's own "Ignore" is the answer, as it is for every passive BLE integration.
 
 ### Manual key entry
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Local control of TTLock smart locks over Bluetooth, for [Home Assistant](https:/
 - **Real-time push events** — keypad presses, fingerprint reads, IC-card swipes, mechanical key turns, and auto-lock fires arrive as Home Assistant events the moment the lock emits them.
 - **Battery sensor** — diagnostic entity refreshed by every poll *and* every push, no extra BLE traffic.
 - **Clock alignment** — the lock's own clock, which stamps every operation-log record, is compared against local time once a day on a session something else already opened, and corrected when it has wandered. A diagnostic sensor reports the measured drift.
+- **Bluetooth discovery** — a lock in range of any radio Home Assistant manages shows up on its own as a discovered device; the address and the frame header come off the advertisement, so only the keys are left to provide.
 - **2FA-aware config flow** — handles TTLock's "new device" verification by emailing a one-time code and prompting for it.
 - **Works without a cloud account** — a lock initialised locally can be added by entering its key directly, no TTLock account involved at any point.
 - **Passive state tracking** — the bolt position and battery level are read from the lock's own BLE advertisements, with no connection and no battery cost. This is what catches an auto-lock or an operation done from the official app.
@@ -43,7 +44,7 @@ The event entity classifies each record as `unlock`, `lock`, `unlock_failed`, `p
 
 1. Install via HACS using the button above, or add this repo as a custom HACS repository (category: Integration).
 2. Restart Home Assistant.
-3. Settings → Devices & Services → Add Integration → **TTLock BLE**.
+3. Settings → Devices & Services → either pick the **TTLock BLE** card already waiting under *Discovered* (any lock in range of a radio Home Assistant manages announces itself), or Add Integration → **TTLock BLE**.
 4. Choose how the keys are obtained:
    - **Sign in to a TTLock account** — enter the email + password you use in the official app. If TTLock has never seen this Home Assistant before it emails a verification code; paste it into the next step. Every lock on the account is synced at once.
    - **Enter a lock key manually** — for a lock initialised outside the cloud. See below.
@@ -61,11 +62,13 @@ A lock initialised by a local BLE bridge never goes through the cloud, and its o
 | Admin passcode | optional, digits; only needed for managing passcodes |
 | Protocol type / version / scene / group ID / organisation ID | the frame header the lock expects. The defaults (5, 3, 2, 1, 1) suit most V3 locks |
 
+Started from a discovered lock, the MAC address, the name and the first three protocol numbers arrive pre-filled from the advertisement — the keys are all that is left to type.
+
 Only these reach the wire. The rest of what the cloud returns per key — user id, lock-flag position, validity window — is never read by the Bluetooth layer, which addresses the lock with a zeroed user id and the firmware's "permanent key" date literals regardless.
 
 If the lock is in range when the form is submitted, the protocol type, version and scene are checked against what it broadcasts, so a wrong value is caught there instead of becoming a lock that never answers. Getting a value wrong later is fixable through the integration's three-dot menu → **Reconfigure**.
 
-The Bluetooth radio HA already manages (USB dongle, built-in adapter, or proxy) discovers the lock automatically — no additional configuration.
+Reaching the lock takes no extra configuration: whatever Bluetooth radio Home Assistant already manages — USB dongle, built-in adapter, or an ESPHome proxy — is the one used.
 
 ## Options
 
@@ -115,7 +118,7 @@ custom_components/ttlock_ble/
 ├── api.py             # TtlockBleApiClient: TTLockCloud wrapper (cloud bootstrap only)
 ├── binary_sensor.py   # TtlockBleConnectionBinarySensor: live BLE link state
 ├── brand/             # icon / logo PNGs (local placeholder for HA brand registry)
-├── config_flow.py     # menu / cloud / manual / verify_code / reauth / reconfigure
+├── config_flow.py     # menu / bluetooth / cloud / manual / verify_code / reauth / reconfigure
 ├── connection.py      # TtlockBleConnection: persistent BLE session per lock
 ├── const.py           # DOMAIN, LOGGER, defaults
 ├── coordinator.py     # DataUpdateCoordinator polling each connection

--- a/custom_components/ttlock_ble/advertisement.py
+++ b/custom_components/ttlock_ble/advertisement.py
@@ -18,6 +18,8 @@ from ttlock_ble import LockAdvertisement
 from .const import LOGGER
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from homeassistant.components.bluetooth import (
         BluetoothChange,
         BluetoothServiceInfoBleak,
@@ -78,7 +80,7 @@ class TtlockBleAdvertisementTracker:
         _change: BluetoothChange,
     ) -> None:
         """Publish whatever the advertisement carries, and nothing more."""
-        advertisement = self._decode(mac, service_info)
+        advertisement = decode_lock_advertisement(mac, service_info.manufacturer_data)
         if advertisement is not None:
             self._coordinator.async_apply_advertisement(mac, advertisement)
             return
@@ -92,33 +94,30 @@ class TtlockBleAdvertisementTracker:
             },
         )
 
-    def _decode(
-        self,
-        mac: str,
-        service_info: BluetoothServiceInfoBleak,
-    ) -> LockAdvertisement | None:
-        """
-        Return the entry of `manufacturer_data` that decodes as this lock's state.
 
-        The address the advertisement carries has to match the lock we
-        expect: a payload long enough to decode is not proof that it is a
-        TTLock payload, and the trailing address is the only field with a
-        value we can check independently.
-        """
-        expected = format_mac(mac)
-        for company_id, payload in service_info.manufacturer_data.items():
-            advertisement = LockAdvertisement.from_manufacturer_data(
-                company_id,
-                payload,
-            )
-            if advertisement is None:
-                continue
-            if format_mac(advertisement.lock_mac) == expected:
-                return advertisement
-            LOGGER.debug(
-                "Ignoring advertisement for %s: decoded address %s does not match (%s)",
-                mac,
-                advertisement.lock_mac,
-                payload.hex(),
-            )
-        return None
+def decode_lock_advertisement(
+    mac: str,
+    manufacturer_data: Mapping[int, bytes],
+) -> LockAdvertisement | None:
+    """
+    Return the entry of `manufacturer_data` that decodes as `mac`'s lock state.
+
+    The address the advertisement carries has to match the lock we
+    expect: a payload long enough to decode is not proof that it is a
+    TTLock payload, and the trailing address is the only field with a
+    value we can check independently.
+    """
+    expected = format_mac(mac)
+    for company_id, payload in manufacturer_data.items():
+        advertisement = LockAdvertisement.from_manufacturer_data(company_id, payload)
+        if advertisement is None:
+            continue
+        if format_mac(advertisement.lock_mac) == expected:
+            return advertisement
+        LOGGER.debug(
+            "Ignoring advertisement for %s: decoded address %s does not match (%s)",
+            mac,
+            advertisement.lock_mac,
+            payload.hex(),
+        )
+    return None

--- a/custom_components/ttlock_ble/config_flow.py
+++ b/custom_components/ttlock_ble/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util import slugify
 
+from .advertisement import decode_lock_advertisement
 from .api import TtlockBleApiClient
 from .const import DOMAIN, LOGGER
 from .exceptions import (
@@ -28,6 +29,10 @@ from .options_flow import TtlockBleOptionsFlow
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+
+    from ttlock_ble import LockAdvertisement
+
     from .data import (
         TtlockBleConfigData,
         TtlockBleConfigEntry,
@@ -40,6 +45,7 @@ if TYPE_CHECKING:
 
 CONF_VERIFICATION_CODE = "verification_code"
 ABORT_ALREADY_CONFIGURED = "already_configured"
+ABORT_NOT_A_LOCK = "not_a_lock"
 DEFAULT_PROTOCOL_TYPE = 5
 DEFAULT_PROTOCOL_VERSION = 3
 DEFAULT_SCENE = 2
@@ -160,6 +166,9 @@ class TtlockBleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     _username: str
     _password: str
+    _discovery: BluetoothServiceInfoBleak | None = None
+    _discovered_advertisement: LockAdvertisement | None = None
+    _discovered_name: str = ""
 
     @staticmethod
     @callback
@@ -178,6 +187,51 @@ class TtlockBleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> config_entries.ConfigFlowResult:
         """Offer the two ways of obtaining a lock's keys."""
         return self.async_show_menu(step_id="user", menu_options=["cloud", "manual"])
+
+    async def async_step_bluetooth(
+        self,
+        discovery_info: BluetoothServiceInfoBleak,
+    ) -> config_entries.ConfigFlowResult:
+        """
+        Handle a lock the bluetooth manager heard advertise.
+
+        The manifest matcher is the manufacturer id alone, which is the
+        protocol header of a V3 lock and nothing more specific; the
+        decode plus the address cross-check is what separates a real
+        lock from anything else that happens to broadcast under it.
+        """
+        advertisement = decode_lock_advertisement(
+            discovery_info.address,
+            discovery_info.manufacturer_data,
+        )
+        if advertisement is None:
+            return self.async_abort(reason=ABORT_NOT_A_LOCK)
+        await self.async_set_unique_id(format_mac(discovery_info.address))
+        self._abort_if_unique_id_configured()
+        self._abort_if_lock_configured(discovery_info.address)
+        self._discovery = discovery_info
+        self._discovered_advertisement = advertisement
+        self._discovered_name = discovery_info.name or discovery_info.address
+        self.context["title_placeholders"] = {"name": self._discovered_name}
+        return await self.async_step_bluetooth_confirm()
+
+    async def async_step_bluetooth_confirm(
+        self,
+        user_input: TtlockBleCredentialsInput | None = None,  # noqa: ARG002
+    ) -> config_entries.ConfigFlowResult:
+        """
+        Offer the two key routes for a lock that was found, not typed in.
+
+        Discovery hands over the address and the frame header, never the
+        AES and unlock keys — those exist only in a TTLock account or in
+        whatever provisioned the lock locally. So this is the same menu
+        the manual entry point shows, with the lock already identified.
+        """
+        return self.async_show_menu(
+            step_id="bluetooth_confirm",
+            menu_options=["cloud", "manual"],
+            description_placeholders={"name": self._discovered_name},
+        )
 
     async def async_step_cloud(
         self,
@@ -228,7 +282,7 @@ class TtlockBleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
         return self.async_show_form(
             step_id="manual",
-            data_schema=_manual_key_schema(user_input),
+            data_schema=_manual_key_schema(user_input or self._discovered_defaults()),
             errors=errors,
         )
 
@@ -322,6 +376,54 @@ class TtlockBleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+    @callback
+    def _discovered_defaults(self) -> TtlockBleManualKeyInput | None:
+        """
+        Pre-fill the manual form with everything the advertisement already said.
+
+        The address, the name and three of the five frame-header
+        integers come off the air, so what is left to type is what only
+        the owner has. It also removes the class of typo the header
+        cross-check exists to catch.
+        """
+        if self._discovery is None or self._discovered_advertisement is None:
+            return None
+        return {
+            "lock_mac": self._discovery.address,
+            "aes_key": "",
+            "unlock_key": "",
+            "admin_passcode": "",
+            "lock_name": self._discovery.name or "",
+            "protocol_type": self._discovered_advertisement.protocol_type,
+            "protocol_version": self._discovered_advertisement.protocol_version,
+            "scene": self._discovered_advertisement.scene,
+            "group_id": DEFAULT_GROUP_ID,
+            "org_id": DEFAULT_ORG_ID,
+        }
+
+    @callback
+    def _discovered_lock_missing_from(
+        self,
+        keys: list[TtlockBleStoredKey],
+    ) -> dict[str, str]:
+        """
+        Refuse an account that does not hold the lock the discovery was about.
+
+        The flow was started from a card naming one lock; an account
+        without it would silently create an entry for a different set of
+        locks and leave the discovered one still unconfigured.
+        """
+        if self._discovery is None:
+            return {}
+        target = format_mac(self._discovery.address)
+        if any(format_mac(key["lockMac"]) == target for key in keys):
+            return {}
+        LOGGER.warning(
+            "The account holds no key for the discovered lock %s",
+            self._discovery.address,
+        )
+        return {"base": "lock_not_in_account"}
 
     @callback
     def _abort_if_lock_configured(
@@ -483,6 +585,9 @@ class TtlockBleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         keys, errors = await self._async_fetch_keys()
         if errors:
             return None, errors
+        missing = self._discovered_lock_missing_from(keys)
+        if missing:
+            return None, missing
         self._abort_if_any_lock_configured(keys)
         data: TtlockBleConfigData = {
             "username": self._username,

--- a/custom_components/ttlock_ble/manifest.json
+++ b/custom_components/ttlock_ble/manifest.json
@@ -1,6 +1,12 @@
 {
   "domain": "ttlock_ble",
   "name": "TTLock BLE",
+  "bluetooth": [
+    {
+      "connectable": false,
+      "manufacturer_id": 773
+    }
+  ],
   "codeowners": [
     "@roquerodrigo"
   ],

--- a/custom_components/ttlock_ble/manual_key.py
+++ b/custom_components/ttlock_ble/manual_key.py
@@ -6,14 +6,16 @@ import re
 from typing import TYPE_CHECKING
 
 from homeassistant.components.bluetooth import async_last_service_info
-from homeassistant.helpers.device_registry import format_mac
 
-from ttlock_ble import LockAdvertisement, LockVersion, VirtualKey
+from ttlock_ble import LockVersion, VirtualKey
 
+from .advertisement import decode_lock_advertisement
 from .const import LOGGER
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+
+    from ttlock_ble import LockAdvertisement
 
     from .data import TtlockBleManualKeyInput, TtlockBleStoredKey
 
@@ -151,18 +153,7 @@ class TtlockBleManualKey:
         service_info = async_last_service_info(self._hass, mac, connectable=False)
         if service_info is None:
             return None
-        expected = format_mac(mac)
-        for company_id, payload in service_info.manufacturer_data.items():
-            advertisement = LockAdvertisement.from_manufacturer_data(
-                company_id,
-                payload,
-            )
-            if (
-                advertisement is not None
-                and format_mac(advertisement.lock_mac) == expected
-            ):
-                return advertisement
-        return None
+        return decode_lock_advertisement(mac, service_info.manufacturer_data)
 
 
 def _normalized_mac(raw: str) -> str:

--- a/custom_components/ttlock_ble/translations/en.json
+++ b/custom_components/ttlock_ble/translations/en.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Set up TTLock BLE",
@@ -7,6 +8,14 @@
         "menu_options": {
           "cloud": "Sign in to a TTLock account",
           "manual": "Enter a lock key manually"
+        }
+      },
+      "bluetooth_confirm": {
+        "title": "Set up {name}",
+        "description": "This lock was found over Bluetooth. Its address and protocol header are already known; what is still missing are its keys, which live either in a TTLock account or in whatever provisioned the lock locally.",
+        "menu_options": {
+          "cloud": "Sign in to a TTLock account",
+          "manual": "Enter this lock's key manually"
         }
       },
       "cloud": {
@@ -83,13 +92,15 @@
       "invalid_aes_key": "The AES key must be 16 bytes of hex.",
       "invalid_unlock_key": "The unlock key must be digits only.",
       "invalid_admin_passcode": "The admin passcode must be digits only.",
-      "protocol_mismatch": "The lock is broadcasting a different protocol type, version or scene than the one entered. Check the values against your lock data."
+      "protocol_mismatch": "The lock is broadcasting a different protocol type, version or scene than the one entered. Check the values against your lock data.",
+      "lock_not_in_account": "This account holds no key for the lock that was found. Sign in with the account that owns it, or enter its key manually."
     },
     "abort": {
       "already_configured": "This lock or account is already configured.",
       "reauth_successful": "Re-authentication was successful.",
       "reconfigure_successful": "Reconfiguration was successful.",
-      "wrong_account": "The credentials entered belong to a different TTLock account. Re-authenticate with the account this entry was created from."
+      "wrong_account": "The credentials entered belong to a different TTLock account. Re-authenticate with the account this entry was created from.",
+      "not_a_lock": "This Bluetooth device is not a TTLock lock."
     }
   },
   "options": {

--- a/custom_components/ttlock_ble/translations/en.json
+++ b/custom_components/ttlock_ble/translations/en.json
@@ -11,8 +11,8 @@
         }
       },
       "bluetooth_confirm": {
-        "title": "Set up {name}",
-        "description": "This lock was found over Bluetooth. Its address and protocol header are already known; what is still missing are its keys, which live either in a TTLock account or in whatever provisioned the lock locally.",
+        "title": "Set up TTLock BLE",
+        "description": "**{name}** was found over Bluetooth. Its address and protocol header are already known; what is still missing are its keys, which live either in a TTLock account or in whatever provisioned the lock locally.",
         "menu_options": {
           "cloud": "Sign in to a TTLock account",
           "manual": "Enter this lock's key manually"

--- a/custom_components/ttlock_ble/translations/pt-BR.json
+++ b/custom_components/ttlock_ble/translations/pt-BR.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Configurar TTLock BLE",
@@ -7,6 +8,14 @@
         "menu_options": {
           "cloud": "Entrar com uma conta TTLock",
           "manual": "Inserir uma chave manualmente"
+        }
+      },
+      "bluetooth_confirm": {
+        "title": "Configurar {name}",
+        "description": "Esta fechadura foi encontrada por Bluetooth. O endereço e o cabeçalho de protocolo já são conhecidos; faltam as chaves, que ficam em uma conta TTLock ou no que tiver inicializado a fechadura localmente.",
+        "menu_options": {
+          "cloud": "Entrar em uma conta TTLock",
+          "manual": "Informar a chave desta fechadura manualmente"
         }
       },
       "cloud": {
@@ -83,13 +92,15 @@
       "invalid_aes_key": "A chave AES precisa ter 16 bytes em hexadecimal.",
       "invalid_unlock_key": "A chave de destravamento aceita apenas dígitos.",
       "invalid_admin_passcode": "A senha de administrador aceita apenas dígitos.",
-      "protocol_mismatch": "A fechadura está anunciando um tipo de protocolo, versão ou cena diferente do que foi informado. Confira os valores nos dados da sua fechadura."
+      "protocol_mismatch": "A fechadura está anunciando um tipo de protocolo, versão ou cena diferente do que foi informado. Confira os valores nos dados da sua fechadura.",
+      "lock_not_in_account": "Esta conta não possui chave para a fechadura encontrada. Entre com a conta dona dela ou informe a chave manualmente."
     },
     "abort": {
       "already_configured": "Esta fechadura ou conta já está configurada.",
       "reauth_successful": "Re-autenticação concluída com sucesso.",
       "reconfigure_successful": "Reconfiguração concluída com sucesso.",
-      "wrong_account": "As credenciais informadas pertencem a outra conta TTLock. Autentique novamente com a conta que originou esta entrada."
+      "wrong_account": "As credenciais informadas pertencem a outra conta TTLock. Autentique novamente com a conta que originou esta entrada.",
+      "not_a_lock": "Este dispositivo Bluetooth não é uma fechadura TTLock."
     }
   },
   "options": {

--- a/custom_components/ttlock_ble/translations/pt-BR.json
+++ b/custom_components/ttlock_ble/translations/pt-BR.json
@@ -11,8 +11,8 @@
         }
       },
       "bluetooth_confirm": {
-        "title": "Configurar {name}",
-        "description": "Esta fechadura foi encontrada por Bluetooth. O endereço e o cabeçalho de protocolo já são conhecidos; faltam as chaves, que ficam em uma conta TTLock ou no que tiver inicializado a fechadura localmente.",
+        "title": "Configurar TTLock BLE",
+        "description": "**{name}** foi encontrada por Bluetooth. O endereço e o cabeçalho de protocolo já são conhecidos; faltam as chaves, que ficam em uma conta TTLock ou no que tiver inicializado a fechadura localmente.",
         "menu_options": {
           "cloud": "Entrar em uma conta TTLock",
           "manual": "Informar a chave desta fechadura manualmente"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -658,3 +659,218 @@ async def test_reauth_key_sync_failure_reshows_the_form(
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {"base": "connection"}
     assert entry.data["password"] == "pass"
+
+
+# --- Bluetooth discovery ---------------------------------------------------
+
+DISCOVERED_MAC = "AA:BB:CC:DD:EE:FF"
+DISCOVERED_TAIL = bytes.fromhex("ffeeddccbbaa")
+DISCOVERED_NAME = "S534_ddeeff"
+V3_COMPANY_ID = 0x0305
+
+
+def _discovery_info(
+    *,
+    address: str = DISCOVERED_MAC,
+    manufacturer_data: dict | None = None,
+    name: str = DISCOVERED_NAME,
+) -> MagicMock:
+    """Stand-in for the `BluetoothServiceInfoBleak` the manager hands the flow."""
+    info = MagicMock(name="BluetoothServiceInfoBleak")
+    info.address = address
+    info.name = name
+    info.manufacturer_data = (
+        {V3_COMPANY_ID: bytes([2, 0x00, 70, 0, 0, 0, 0]) + DISCOVERED_TAIL}
+        if manufacturer_data is None
+        else manufacturer_data
+    )
+    return info
+
+
+async def _start_discovery(hass, info: MagicMock | None = None):
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=info if info is not None else _discovery_info(),
+    )
+
+
+def _schema_defaults(schema) -> dict:
+    """Read the pre-filled values off a rendered form schema."""
+    return {
+        str(marker): marker.default()
+        for marker in schema.schema
+        if marker.default is not vol.UNDEFINED
+    }
+
+
+async def test_bluetooth_discovery_offers_both_routes(
+    hass,
+    enable_custom_integrations,
+) -> None:
+    result = await _start_discovery(hass)
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "bluetooth_confirm"
+    assert result["menu_options"] == ["cloud", "manual"]
+    assert result["description_placeholders"] == {"name": DISCOVERED_NAME}
+
+
+async def test_bluetooth_discovery_titles_the_card_with_the_lock(
+    hass,
+    enable_custom_integrations,
+) -> None:
+    result = await _start_discovery(hass)
+    flow = hass.config_entries.flow.async_get(result["flow_id"])
+    assert flow["context"]["title_placeholders"] == {"name": DISCOVERED_NAME}
+
+
+async def test_bluetooth_discovery_falls_back_to_the_address(
+    hass,
+    enable_custom_integrations,
+) -> None:
+    """A lock advertising no name is still identified by something."""
+    result = await _start_discovery(hass, _discovery_info(name=""))
+    assert result["description_placeholders"] == {"name": DISCOVERED_MAC}
+
+
+async def test_bluetooth_discovery_ignores_a_foreign_advertisement(
+    hass,
+    enable_custom_integrations,
+) -> None:
+    """The manufacturer id alone is not proof the payload is a lock's."""
+    result = await _start_discovery(
+        hass,
+        _discovery_info(manufacturer_data={0x004C: b"\x02\x15"}),
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "not_a_lock"
+
+
+async def test_bluetooth_discovery_rejects_a_mismatched_address(
+    hass,
+    enable_custom_integrations,
+) -> None:
+    """A decodable payload carrying somebody else's address is not this lock."""
+    result = await _start_discovery(
+        hass,
+        _discovery_info(
+            manufacturer_data={
+                V3_COMPANY_ID: bytes([2, 0x00, 70, 0, 0, 0, 0])
+                + bytes.fromhex("112233445566"),
+            },
+        ),
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "not_a_lock"
+
+
+async def test_bluetooth_discovery_aborts_for_a_manual_entry(
+    hass,
+    enable_custom_integrations,
+    sample_stored_key,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"keys": [sample_stored_key]},
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    entry.add_to_hass(hass)
+    result = await _start_discovery(hass)
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_bluetooth_discovery_aborts_for_a_cloud_entry(
+    hass,
+    enable_custom_integrations,
+    sample_stored_key,
+) -> None:
+    """A cloud entry is keyed by the account, so only the key scan catches it."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "user@example.com", "password": "pass"},
+        unique_id="user_example_com",
+    )
+    entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, "keys": [sample_stored_key]},
+    )
+    result = await _start_discovery(hass)
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_bluetooth_discovery_prefills_the_manual_form(
+    hass,
+    enable_custom_integrations,
+) -> None:
+    """What the lock broadcast is what the form no longer asks for."""
+    discovery = await _start_discovery(hass)
+    result = await hass.config_entries.flow.async_configure(
+        discovery["flow_id"], user_input={"next_step_id": "manual"}
+    )
+    defaults = _schema_defaults(result["data_schema"])
+    assert defaults["lock_mac"] == DISCOVERED_MAC
+    assert defaults["lock_name"] == DISCOVERED_NAME
+    assert defaults["protocol_type"] == 5
+    assert defaults["protocol_version"] == 3
+    assert defaults["scene"] == 2
+    assert defaults["aes_key"] == ""
+    assert defaults["unlock_key"] == ""
+
+
+async def test_manual_step_without_discovery_keeps_its_own_defaults(
+    hass,
+    enable_custom_integrations,
+) -> None:
+    menu = await _start_menu(hass)
+    result = await hass.config_entries.flow.async_configure(
+        menu["flow_id"], user_input={"next_step_id": "manual"}
+    )
+    defaults = _schema_defaults(result["data_schema"])
+    assert defaults["lock_mac"] == ""
+    assert defaults["protocol_type"] == 5
+
+
+async def test_bluetooth_discovery_cloud_branch_creates_the_entry(
+    hass,
+    enable_custom_integrations,
+    sample_virtual_key,
+) -> None:
+    discovery = await _start_discovery(hass)
+    with _patch_client(list_keys=[sample_virtual_key]):
+        menu = await hass.config_entries.flow.async_configure(
+            discovery["flow_id"], user_input={"next_step_id": "cloud"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            menu["flow_id"], user_input=USER_INPUT
+        )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"]["keys"][0]["lockMac"] == DISCOVERED_MAC
+
+
+async def test_bluetooth_discovery_cloud_branch_rejects_a_foreign_account(
+    hass,
+    enable_custom_integrations,
+    sample_virtual_key,
+) -> None:
+    """Signing in with an account that does not hold the found lock is a mistake."""
+    other = _discovery_info(
+        address="11:22:33:44:55:66",
+        manufacturer_data={
+            V3_COMPANY_ID: bytes([2, 0x00, 70, 0, 0, 0, 0])
+            + bytes.fromhex("665544332211"),
+        },
+    )
+    discovery = await _start_discovery(hass, other)
+    with _patch_client(list_keys=[sample_virtual_key]):
+        menu = await hass.config_entries.flow.async_configure(
+            discovery["flow_id"], user_input={"next_step_id": "cloud"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            menu["flow_id"], user_input=USER_INPUT
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "lock_not_in_account"}
+    assert not hass.config_entries.async_entries(DOMAIN)

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -102,3 +102,26 @@ def test_no_empty_translation_values():
             for part in key.split("."):
                 value = value[part]
             assert value, f"{path.name} has empty value for {key}"
+
+
+@pytest.mark.parametrize("locale", [f.stem for f in _translation_files()])
+def test_config_step_titles_carry_no_placeholder(locale):
+    """
+    A step title is rendered without the step's placeholders.
+
+    Home Assistant localizes config-step titles in contexts that pass no
+    `description_placeholders` — the add-integration dialog among them —
+    so a `{name}` there resolves to nothing and the frontend logs a
+    formatting failure on every render. The placeholder belongs in the
+    step's `description`, or in `flow_title`, which is only formatted
+    when the flow actually carries title placeholders.
+    """
+    steps = json.loads(
+        (TRANSLATIONS_DIR / f"{locale}.json").read_text(encoding="utf-8"),
+    )["config"]["step"]
+    offenders = {
+        step_id: body["title"]
+        for step_id, body in steps.items()
+        if "{" in body.get("title", "")
+    }
+    assert not offenders, f"{locale}.json step titles use placeholders: {offenders}"

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,7 @@ wheels = [
 
 [[package]]
 name = "ha-ttlock-ble"
-version = "3.7.0"
+version = "3.8.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

A TTLock lock in range of any Bluetooth radio Home Assistant manages now appears on its own under **Discovered**, instead of having to be added from the integration list.

The advertisement carries the lock's address and frame header, never the AES and unlock keys — those exist only in a TTLock account or in whatever provisioned the lock locally. Discovery therefore leads into the two routes that already exist rather than completing an entry by itself:

- **Sign in to a TTLock account** — unchanged, except that an account which does not hold the discovered lock is rejected in the form instead of quietly creating an entry for a different set of locks.
- **Enter a lock key manually** — the MAC address, the name and the protocol type, version and scene arrive pre-filled from the advertisement, leaving only the keys to type. This also removes the class of typo the existing header cross-check exists to catch.

## Matching

`manifest.json` declares a single matcher, `manufacturer_id: 773` (`0x0305` — the protocol type and version of a V3 lock, which is what the manufacturer-data company id is on this firmware) with `connectable: false`, so a lock heard only through a non-connectable proxy still raises the flow.

The matcher is deliberately broad and the flow is what narrows it: the payload has to decode as lock state *and* carry the address it was heard from, or the flow aborts. A lock already held by another entry raises no card — both collision checks run, since a manual entry is keyed by the MAC and a cloud entry by the account.

Locks older than the 5.3 header are not covered and continue to use manual entry. A TTLock belonging to someone else, in range, also raises a card; Home Assistant's own **Ignore** is the answer, as for every passive BLE integration.

## Notes

- The advertisement decoder is now a module-level function in `advertisement.py`, shared by the passive tracker, the manual key form and the config flow, instead of being written a third time.
- Docs updated in `README.md` and `CLAUDE.md`; both locales gained the discovery strings.
- The lockfile's own project version is synced to the released 3.8.0.

## Verification

`ruff format --check`, `ruff check`, `mypy` and `pytest` all pass; coverage is at 100%. Eleven new tests cover the discovery step, the two abort paths, the pre-filled manual form and both cloud outcomes.

Checked against a live lock as well: Home Assistant's loader reads the new matcher from the installed manifest, and its integration matcher returns `{'ttlock_ble'}` for the lock's real advertisement, which decodes to protocol 5.3 scene 2 with the address matching.