### PR TITLE
docs: add GitHub Sponsors button and support section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: roquerodrigo

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/roquerodrigo/ha-ttlock-ble/actions/workflows/ci.yml/badge.svg)](https://github.com/roquerodrigo/ha-ttlock-ble/actions/workflows/ci.yml)
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
 
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-db61a2?logo=githubsponsors&logoColor=white&style=for-the-badge)](https://github.com/sponsors/roquerodrigo)
+
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=roquerodrigo&repository=ha-ttlock-ble&category=integration)
 
 ---
@@ -159,6 +161,10 @@ This wires ruff, mypy and basic file hygiene checks (`.pre-commit-config.yaml`) 
 - **`codeql.yml`** — GitHub CodeQL security scan; push/PR to `main` and a weekly cron
 - **`release.yml`** — release-please opens a release PR on every push to `main` based on conventional commits
 - **`auto-assign.yml`** — assigns the repository owner to new issues and pull requests
+
+## Support
+
+This integration is built and maintained on personal time, on hardware bought for the purpose. If it is useful to you, consider [sponsoring the work](https://github.com/sponsors/roquerodrigo) — it keeps the devices, the testing and the releases coming.
 
 ## License
 


### PR DESCRIPTION
Adds funding metadata so the repository shows a **Sponsor** button in its header, and points to it from the README.

- `.github/FUNDING.yml` — enables the native Sponsor button and the sponsor entry in the repository menu.
- README — a Sponsor badge at the top, next to the existing badges, and a short support section above the closing sections.

Documentation only; no runtime or packaging changes.
