### PR TITLE
feat(switch): read the beep setting back from the lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ The lock stamps every operation-log record from an RTC it keeps itself: no NTP, 
 
 ### Sound switch
 
-`switch.py` toggles the lock's keypad/lock beep. Two constraints shape it. It is `assumed_state`, because the firmware has no opcode reporting the setting back — neither a query nor the advertisement carries it — so the entity shows the last value it sent, which stops being true the moment the official app changes it; HA renders that as two buttons rather than one toggle, which is the honest presentation. And it is only created for a key that is both `is_admin()` and carries an `adminPs`: the firmware gates the command behind CHECK_ADMIN, and a manual-key entry usually has neither, where the entity could only ever fail.
+`switch.py` toggles the lock's keypad/lock beep. Two constraints shape it. Its value comes from the coordinator, which reads the setting with `get_lock_sound()` on a session opened for something else — the poll after a command, or an advertised operation-log read that landed — never by connecting for it, and at most once per `SOUND_CHECK_INTERVAL_SECONDS`, because the read costs the admin handshake and the official app is the only thing that changes the setting behind our back. A write the lock accepted is adopted straight away through `async_note_sound_enabled`, and the next paced read confirms it. Until either has happened the entity reports `unknown`. And it is only created for a key that `can_administer` (`key_privileges.py`: both `is_admin()` and an `adminPs`): the firmware gates the command and the read behind CHECK_ADMIN, and a manual-key entry usually has neither, where the entity could only ever fail — the coordinator applies the same test before reading, so such a key is never asked.
 
 ### Diagnostics
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Each configured lock produces one HA device, named with the model, hardware and 
 | `event.<alias>_log` | `event` | Fires for every new operation-log record read from the lock. |
 | `sensor.<alias>_last_seen` | `sensor` | When the lock was last heard from, read from HA's own advertisement history (diagnostic). |
 | `sensor.<alias>_clock_drift` | `sensor` | How far the lock's own clock was off local time when last compared, in seconds, positive when it runs ahead (diagnostic). `unknown` until a session opened for something else has carried a comparison. |
-| `switch.<alias>_sound` | `switch` | The lock's keypad/lock beep. Assumed state — the firmware reports no readback — and only created for an admin key that carries an admin passcode, which a manually entered key usually does not. |
+| `switch.<alias>_sound` | `switch` | The lock's keypad/lock beep, read back from the lock on sessions opened for something else and re-read at most hourly. `unknown` until a session has carried a read. Only created for an admin key that carries an admin passcode, which a manually entered key usually does not. |
 
 The event entity classifies each record as `unlock`, `lock`, `unlock_failed`, `password_change` or `other`, and attaches `record_type` and `battery` always, plus `timestamp`, `uid`, `credential`, `key_id` and `accessory_battery` when the record carries them. `credential` is only populated for record types where the value is an identifier (card number, fingerprint id, fob MAC) — record types where it would be a working door code never expose it.
 

--- a/custom_components/ttlock_ble/connection.py
+++ b/custom_components/ttlock_ble/connection.py
@@ -32,7 +32,14 @@ if TYPE_CHECKING:
     from bleak import BleakClient
     from homeassistant.core import HomeAssistant
 
-    from ttlock_ble import DeviceInfo, LockEvent, LockState, LogEntry, VirtualKey
+    from ttlock_ble import (
+        DeviceInfo,
+        LockEvent,
+        LockSound,
+        LockState,
+        LogEntry,
+        VirtualKey,
+    )
 
 
 RECONNECT_INITIAL_BACKOFF = 1.0
@@ -210,6 +217,31 @@ class TtlockBleConnection:
                 # caller keeps whatever it knew and tries again later.
                 LOGGER.debug(
                     "get_lock_time failed for %s: %s",
+                    self._key.lockMac,
+                    exc,
+                )
+                return None
+
+    async def async_get_lock_sound(self) -> LockSound | None:
+        """
+        Read the lock's beep setting through the connection.
+
+        Returns `None` when the lock is out of range or the read failed.
+        Admin-gated by the firmware like the write is, so a key carrying
+        no admin password can only ever fail here; callers check that
+        before asking.
+        """
+        async with self._lock:
+            client = await self._async_ensure_connected_locked()
+            if client is None:
+                return None
+            try:
+                return await client.get_lock_sound()
+            except Exception as exc:  # noqa: BLE001
+                # A settings read is not worth losing the poll that
+                # carried it: the caller keeps whatever it knew.
+                LOGGER.debug(
+                    "get_lock_sound failed for %s: %s",
                     self._key.lockMac,
                     exc,
                 )

--- a/custom_components/ttlock_ble/coordinator.py
+++ b/custom_components/ttlock_ble/coordinator.py
@@ -31,6 +31,7 @@ from homeassistant.util import dt as dt_util
 from ttlock_ble import LockState
 
 from .const import DOMAIN, LOGGER
+from .key_privileges import can_administer
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -77,6 +78,12 @@ CLOCK_CHECK_INTERVAL_SECONDS = 24 * 60 * 60
 # on every check and pay for it in battery.
 CLOCK_DRIFT_THRESHOLD_SECONDS = 30.0
 
+# How long between reads of the beep setting. The official app can change
+# it at any time and nothing announces that, so it is re-read on a session
+# opened for something else - but not on every one: the read costs the
+# admin handshake plus its own round trip, and the setting rarely moves.
+SOUND_CHECK_INTERVAL_SECONDS = 60 * 60
+
 # Above this, a correction is worth a line in the log at INFO. A lock
 # does not drift by minutes on its own - a gap that size usually means
 # it was set up on a different wall clock than Home Assistant keeps.
@@ -110,6 +117,8 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
         self._descriptions = descriptions
         self._clock_syncs = clock_syncs
         self._described: set[str] = set()
+        self._sound_enabled: dict[str, bool] = {}
+        self._sound_checked_at: dict[str, float] = {}
         self._log_fetches: set[str] = set()
         self._records_pending: dict[str, bool] = {}
         self._log_retries: dict[str, CALLBACK_TYPE] = {}
@@ -150,6 +159,23 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
     def async_clock_sync(self, mac: str) -> TtlockBleClockSync | None:
         """Return the last clock comparison for `mac`, if there was one."""
         return self._clock_syncs.get(mac)
+
+    @callback
+    def async_sound_enabled(self, mac: str) -> bool | None:
+        """Return whether the beep of `mac` is on, as last read or written."""
+        return self._sound_enabled.get(mac)
+
+    @callback
+    def async_note_sound_enabled(self, mac: str, *, enabled: bool) -> None:
+        """
+        Adopt a value the lock just accepted, without reading it back.
+
+        A raise-free write means the lock took the frame, and reading the
+        setting straight back would spend another handshake to learn what
+        was just sent. The paced read confirms it on a later session.
+        """
+        self._sound_enabled[mac] = enabled
+        self.async_update_listeners()
 
     @callback
     def async_has_state(self, mac: str) -> bool:
@@ -366,6 +392,7 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
             # failure above must not reach the retry bookkeeping below
             # as if the log itself had failed.
             await self._async_align_clock(connection)
+            await self._async_read_sound(connection)
         finally:
             self._log_fetches.discard(mac)
             if self._records_pending.get(mac, False):
@@ -411,6 +438,7 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
             )
         await self._async_describe(connection)
         await self._async_align_clock(connection)
+        await self._async_read_sound(connection)
         return {
             "locked": _parse_lock_state(raw_state),
             "battery_level": battery,
@@ -516,6 +544,33 @@ class TtlockBleDataUpdateCoordinator(DataUpdateCoordinator["TtlockBleCoordinator
             dt_util.now().replace(tzinfo=None)
         ):
             LOGGER.debug("Clock correction did not reach %s", mac)
+
+    async def _async_read_sound(self, connection: TtlockBleConnection) -> None:
+        """
+        Read the beep setting on a session another read just opened.
+
+        The firmware reports it only to an admin key, so a key without
+        the admin password is never asked. A read that did not land
+        leaves the pacing untouched, so the next session tries again
+        rather than waiting out an interval for an answer never given.
+        """
+        mac = connection.key.lockMac
+        if not can_administer(connection.key) or not self._async_sound_check_due(mac):
+            return
+        sound = await connection.async_get_lock_sound()
+        if sound is None:
+            return
+        self._sound_checked_at[mac] = self.hass.loop.time()
+        LOGGER.debug("Sound of %s is %s", mac, "on" if sound.enabled else "off")
+        self._sound_enabled[mac] = sound.enabled
+        self.async_update_listeners()
+
+    def _async_sound_check_due(self, mac: str) -> bool:
+        """Report whether `mac` is due for a beep-setting read."""
+        checked_at = self._sound_checked_at.get(mac)
+        if checked_at is None:
+            return True
+        return self.hass.loop.time() - checked_at >= SOUND_CHECK_INTERVAL_SECONDS
 
     def _async_clock_check_due(self, mac: str) -> bool:
         """Report whether `mac` is due for a clock comparison."""

--- a/custom_components/ttlock_ble/data/stored_key.py
+++ b/custom_components/ttlock_ble/data/stored_key.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 if TYPE_CHECKING:
     from .stored_lock_version import TtlockBleStoredLockVersion
@@ -28,4 +28,5 @@ class TtlockBleStoredKey(TypedDict):
     adminPs: str
     keyboardPwdVersion: int
     specialValue: int
+    featureValue: NotRequired[str]
     uid: int

--- a/custom_components/ttlock_ble/event.py
+++ b/custom_components/ttlock_ble/event.py
@@ -102,6 +102,8 @@ UNLOCK_RECORD_TYPES: frozenset[int] = frozenset(
         LogOperate.PALM_VEIN_UNLOCK_SUCCESS,
         LogOperate.ADMIN_CODE_UNLOCK,
         LogOperate.THIRD_DEVICE_UNLOCK_SUCCESS,
+        LogOperate.HIGH_TEMPERATURE_UNLOCK,
+        LogOperate.LOW_BATTERY_AUTO_UNLOCK,
     },
 )
 
@@ -117,6 +119,7 @@ LOCK_RECORD_TYPES: frozenset[int] = frozenset(
         LogOperate.FACE_3D_LOCK,
         LogOperate.PALM_VEIN_LOCK,
         LogOperate.THIRD_DEVICE_LOCK_SUCCESS,
+        LogOperate.QR_CODE_LOCK_SUCCESS,
     },
 )
 
@@ -141,6 +144,7 @@ UNLOCK_FAILED_RECORD_TYPES: frozenset[int] = frozenset(
         LogOperate.CARD_UNLOCK_FAILED,
         LogOperate.THIRD_DEVICE_UNLOCK_FAILED_LOCK_REVERSE,
         LogOperate.THIRD_DEVICE_UNLOCK_FAILED_INVALID_TIME,
+        LogOperate.QR_CODE_UNLOCK_FAILED_LOCK_REVERSE,
     },
 )
 
@@ -194,6 +198,16 @@ UNBUCKETED_RECORD_TYPES: frozenset[int] = frozenset(
         # A verification step of a two-factor flow, not the unlock that
         # may or may not follow it.
         LogOperate.DOUBLE_CHECK_THIRD_DEVICE_VERIFY,
+        # Alarms: the door stayed open, the lock got hot, a fire was
+        # sensed. No bolt operation, and folding them into a bucket
+        # would hide the one thing worth an automation.
+        LogOperate.DOOR_NOT_CLOSE_ALARM,
+        LogOperate.HIGH_TEMPERATURE_ALARM,
+        LogOperate.FIRE_ALARM,
+        # A vendor-specific record the SDK names but does not describe.
+        LogOperate.ANLANGJIE_LOG,
+        # A state read over NFC; nothing moved.
+        LogOperate.GET_NFC_LOCK_STATE,
     },
 )
 

--- a/custom_components/ttlock_ble/key_privileges.py
+++ b/custom_components/ttlock_ble/key_privileges.py
@@ -1,0 +1,20 @@
+"""Which lock settings a `VirtualKey` is allowed to touch."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ttlock_ble import VirtualKey
+
+
+def can_administer(key: VirtualKey) -> bool:
+    """
+    Report whether `key` may read or change lock settings at all.
+
+    The firmware gates settings behind CHECK_ADMIN, which needs both an
+    admin key and the admin passcode that authorises it. A key obtained
+    outside a TTLock account often carries no passcode, and a request
+    that can only ever fail is not worth a BLE round trip.
+    """
+    return key.is_admin() and bool(key.adminPs)

--- a/custom_components/ttlock_ble/manifest.json
+++ b/custom_components/ttlock_ble/manifest.json
@@ -18,7 +18,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/roquerodrigo/ha-ttlock-ble/issues",
   "requirements": [
-    "ttlock-ble==0.3.0"
+    "ttlock-ble==0.3.2"
   ],
   "version": "3.9.0"
 }

--- a/custom_components/ttlock_ble/switch.py
+++ b/custom_components/ttlock_ble/switch.py
@@ -12,6 +12,7 @@ from ttlock_ble import TTLockError
 
 from .const import LOGGER
 from .entity import TtlockBleEntity
+from .key_privileges import can_administer
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -24,18 +25,6 @@ if TYPE_CHECKING:
     from .data import TtlockBleConfigEntry
 
 
-def _can_manage_sound(key: VirtualKey) -> bool:
-    """
-    Report whether this key may change lock settings at all.
-
-    The firmware gates the command behind CHECK_ADMIN, which needs both
-    an admin key and the admin passcode that authorises it. A key
-    obtained outside a TTLock account often carries no passcode, and an
-    entity that can only ever fail is worse than no entity.
-    """
-    return key.is_admin() and bool(key.adminPs)
-
-
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001
     entry: TtlockBleConfigEntry,
@@ -46,7 +35,7 @@ async def async_setup_entry(
     async_add_entities(
         TtlockBleSoundSwitch(data.coordinator, key, data.connections[key.lockMac])
         for key in data.virtual_keys
-        if _can_manage_sound(key)
+        if can_administer(key)
     )
 
 
@@ -54,18 +43,15 @@ class TtlockBleSoundSwitch(TtlockBleEntity, SwitchEntity):
     """
     The lock's keypad/lock beep.
 
-    `assumed_state` because the firmware has no opcode that reports this
-    setting back: neither a query nor the advertisement carries it. What
-    the entity shows is the last value it sent, which stops being true
-    the moment someone changes it from the official app — and is unknown
-    entirely until something sets it. Home Assistant renders an assumed
-    state as two buttons rather than one toggle, which is the honest
-    presentation: the command can be sent, the answer cannot be read.
+    The setting is read from the lock on sessions opened for something
+    else and kept by the coordinator, so what the entity shows is what
+    the lock last reported — or what it last accepted from here, which
+    the next paced read confirms. It is unknown until either has
+    happened: nothing connects just to learn it.
     """
 
     _attr_translation_key = "sound"
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_assumed_state = True
     _attr_icon = "mdi:volume-high"
 
     def __init__(
@@ -77,12 +63,16 @@ class TtlockBleSoundSwitch(TtlockBleEntity, SwitchEntity):
         """Bind the switch to its key + connection."""
         super().__init__(coordinator, key)
         self._connection = connection
-        self._attr_is_on: bool | None = None
 
     @property
     def unique_id(self) -> str:
         """Return a stable unique id for this entity."""
         return f"{self._key.lockMac}_sound"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the beep setting as the coordinator last learned it."""
+        return self.coordinator.async_sound_enabled(self._key.lockMac)
 
     async def async_turn_on(self, **kwargs: Any) -> None:  # noqa: ARG002
         """Turn the beep on."""
@@ -93,7 +83,7 @@ class TtlockBleSoundSwitch(TtlockBleEntity, SwitchEntity):
         await self._async_set(enabled=False)
 
     async def _async_set(self, *, enabled: bool) -> None:
-        """Send the command and adopt what was sent, since nothing reads it back."""
+        """Send the command and adopt what the lock accepted."""
         try:
             await self._connection.async_set_lock_sound(enabled=enabled)
         except TTLockError as exc:
@@ -104,5 +94,4 @@ class TtlockBleSoundSwitch(TtlockBleEntity, SwitchEntity):
             )
             msg = f"Failed to set the sound of {self._key.lockMac}: {exc}"
             raise HomeAssistantError(msg) from exc
-        self._attr_is_on = enabled
-        self.async_write_ha_state()
+        self.coordinator.async_note_sound_enabled(self._key.lockMac, enabled=enabled)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
     "pytest-cov==7.1.0",
     "pytest-homeassistant-custom-component==0.13.354",
     "serialx==1.8.2",
-    "ttlock-ble==0.3.0",
+    "ttlock-ble==0.3.2",
 ]
 lint = [
     "ruff==0.16.4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,15 +153,17 @@ def mock_ttlock_client() -> Generator[MagicMock]:
 
 
 @pytest.fixture
-def mock_ttlock_connection() -> Generator[MagicMock]:
+def mock_ttlock_connection(sample_virtual_key: VirtualKey) -> Generator[MagicMock]:
     """Mock the whole `TtlockBleConnection` class at the integration setup site."""
     instance = MagicMock(name="TtlockBleConnection")
+    instance.key = sample_virtual_key
     instance.async_start = AsyncMock(return_value=None)
     instance.async_stop = AsyncMock(return_value=None)
     instance.async_query_state = AsyncMock(return_value=(0, 80))
     instance.async_get_operation_log = AsyncMock(return_value=[])
     instance.async_get_device_info = AsyncMock(return_value=None)
     instance.async_get_lock_time = AsyncMock(return_value=None)
+    instance.async_get_lock_sound = AsyncMock(return_value=None)
     instance.async_calibrate_time = AsyncMock(return_value=True)
     instance.async_lock = AsyncMock(return_value=None)
     instance.async_unlock = AsyncMock(return_value=None)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from bleak import BleakError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from ttlock_ble import DeviceInfo, LockEvent, TTLockError
+from ttlock_ble import DeviceInfo, LockEvent, LockSound, TTLockError
 
 from custom_components.ttlock_ble.connection import (
     TtlockBleConnection,
@@ -796,6 +796,42 @@ async def test_get_lock_time_that_fails_costs_nothing_else(
     mock_ttlock_client.get_lock_time = AsyncMock(side_effect=TTLockError("link down"))
     conn = TtlockBleConnection(hass, sample_virtual_key)
     assert await conn.async_get_lock_time() is None
+
+
+async def test_get_lock_sound_returns_what_the_lock_reports(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    sound = LockSound(enabled=False, volume=None)
+    mock_ttlock_client.get_lock_sound = AsyncMock(return_value=sound)
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_get_lock_sound() is sound
+
+
+async def test_get_lock_sound_returns_none_when_device_missing(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    mock_ble_resolver.return_value = None
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_get_lock_sound() is None
+    mock_ttlock_client.connect.assert_not_awaited()
+
+
+async def test_get_lock_sound_that_fails_costs_nothing_else(
+    hass,
+    sample_virtual_key,
+    mock_ble_resolver,
+    mock_ttlock_client,
+) -> None:
+    """A settings read is not worth failing the poll that carried it."""
+    mock_ttlock_client.get_lock_sound = AsyncMock(side_effect=TTLockError("refused"))
+    conn = TtlockBleConnection(hass, sample_virtual_key)
+    assert await conn.async_get_lock_sound() is None
 
 
 async def test_calibrate_time_reports_that_it_landed(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,12 +6,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.util import dt as dt_util
-from ttlock_ble import DeviceInfo
+from ttlock_ble import DeviceInfo, LockSound
 
 from custom_components.ttlock_ble.clock_sync_store import TtlockBleClockSyncStore
 from custom_components.ttlock_ble.coordinator import (
     CLOCK_CHECK_INTERVAL_SECONDS,
     CLOCK_DRIFT_THRESHOLD_SECONDS,
+    SOUND_CHECK_INTERVAL_SECONDS,
     TtlockBleDataUpdateCoordinator,
     _parse_lock_state,
 )
@@ -40,6 +41,7 @@ def _mock_connection(*, query_return=(0, 80), mac="AA:BB:CC:DD:EE:FF") -> MagicM
     conn.async_get_operation_log = AsyncMock(return_value=[])
     conn.async_get_device_info = AsyncMock(return_value=None)
     conn.async_get_lock_time = AsyncMock(return_value=None)
+    conn.async_get_lock_sound = AsyncMock(return_value=None)
     conn.async_calibrate_time = AsyncMock(return_value=True)
     return conn
 
@@ -819,3 +821,126 @@ async def test_a_failed_log_read_carries_no_clock_check(hass) -> None:
     await coordinator._async_fetch_operation_log(MAC, conn)
 
     conn.async_get_lock_time.assert_not_awaited()
+
+
+def _sound_connection(*, enabled: bool = True, admin: bool = True) -> MagicMock:
+    """A connection whose lock reports its beep setting when asked."""
+    conn = _mock_connection()
+    conn.key = MagicMock(lockMac=MAC, adminPs="135792468" if admin else "")
+    conn.key.is_admin = MagicMock(return_value=admin)
+    conn.async_get_lock_sound = AsyncMock(
+        return_value=LockSound(enabled=enabled, volume=None)
+    )
+    return conn
+
+
+async def test_the_sound_setting_is_unknown_until_a_session_carries_it(hass) -> None:
+    coordinator = _coordinator(hass, {MAC: _sound_connection()})
+
+    assert coordinator.async_sound_enabled(MAC) is None
+
+
+async def test_a_poll_reads_the_sound_setting(hass) -> None:
+    conn = _sound_connection(enabled=False)
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    conn.async_get_lock_sound.assert_awaited_once()
+    assert coordinator.async_sound_enabled(MAC) is False
+
+
+async def test_the_sound_read_tells_the_entities(hass) -> None:
+    coordinator = _coordinator(hass, {MAC: _sound_connection()})
+    listener = MagicMock()
+    coordinator.async_add_listener(listener)
+
+    await coordinator._async_update_data()
+
+    listener.assert_called()
+
+
+async def test_the_sound_setting_is_read_at_most_once_per_interval(hass) -> None:
+    """Each read costs the admin handshake, and the setting rarely moves."""
+    conn = _sound_connection()
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+
+    conn.async_get_lock_sound.assert_awaited_once()
+
+
+async def test_the_sound_setting_is_read_again_once_the_interval_has_passed(
+    hass,
+) -> None:
+    """The official app can change it at any time, and nothing announces that."""
+    conn = _sound_connection()
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+    coordinator._sound_checked_at[MAC] -= SOUND_CHECK_INTERVAL_SECONDS
+    await coordinator._async_update_data()
+
+    assert conn.async_get_lock_sound.await_count == 2
+
+
+async def test_a_sound_read_that_did_not_land_is_tried_on_the_next_session(
+    hass,
+) -> None:
+    conn = _sound_connection()
+    conn.async_get_lock_sound = AsyncMock(
+        side_effect=[None, LockSound(enabled=True, volume=None)]
+    )
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+    assert coordinator.async_sound_enabled(MAC) is None
+
+    await coordinator._async_update_data()
+    assert coordinator.async_sound_enabled(MAC) is True
+
+
+async def test_a_key_that_cannot_administer_is_never_asked_for_the_sound(
+    hass,
+) -> None:
+    """The firmware refuses the read without CHECK_ADMIN; asking costs a round trip."""
+    conn = _sound_connection(admin=False)
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_update_data()
+
+    conn.async_get_lock_sound.assert_not_awaited()
+    assert coordinator.async_sound_enabled(MAC) is None
+
+
+async def test_the_log_read_carries_the_sound_read(hass) -> None:
+    conn = _sound_connection()
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_fetch_operation_log(MAC, conn)
+
+    conn.async_get_lock_sound.assert_awaited_once()
+
+
+async def test_a_failed_log_read_carries_no_sound_read(hass) -> None:
+    conn = _sound_connection()
+    conn.async_get_operation_log = AsyncMock(side_effect=ValueError("garbled frame"))
+    coordinator = _coordinator(hass, {MAC: conn})
+
+    await coordinator._async_fetch_operation_log(MAC, conn)
+
+    conn.async_get_lock_sound.assert_not_awaited()
+
+
+async def test_a_written_sound_setting_is_adopted_without_a_read(hass) -> None:
+    conn = _sound_connection()
+    coordinator = _coordinator(hass, {MAC: conn})
+    listener = MagicMock()
+    coordinator.async_add_listener(listener)
+
+    coordinator.async_note_sound_enabled(MAC, enabled=False)
+
+    assert coordinator.async_sound_enabled(MAC) is False
+    conn.async_get_lock_sound.assert_not_awaited()
+    listener.assert_called_once()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
-from ttlock_ble import TTLockError
+from ttlock_ble import LockSound, TTLockError
 
 
 def _switch_state(hass):
@@ -16,13 +16,31 @@ async def test_sound_switch_created_for_an_admin_key(hass, setup_integration) ->
 
 
 async def test_sound_switch_starts_without_a_value(hass, setup_integration) -> None:
-    """Nothing reads the setting back, so nothing is known until something sets it."""
+    """Setup opens no session, and nothing connects just to learn the setting."""
     assert _switch_state(hass).state == "unknown"
 
 
-async def test_sound_switch_is_assumed(hass, setup_integration) -> None:
-    """The command can be sent; the answer cannot be read."""
-    assert _switch_state(hass).attributes["assumed_state"] is True
+async def test_sound_switch_is_not_assumed(hass, setup_integration) -> None:
+    """The setting is read from the lock, so one toggle is the honest presentation."""
+    assert "assumed_state" not in _switch_state(hass).attributes
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+async def test_sound_switch_follows_what_the_lock_reports(
+    hass,
+    setup_integration,
+    mock_ttlock_connection,
+    enabled,
+) -> None:
+    mock_ttlock_connection.async_get_lock_sound.return_value = LockSound(
+        enabled=enabled, volume=None
+    )
+    state = _switch_state(hass)
+
+    await setup_integration.runtime_data.coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(state.entity_id).state == ("on" if enabled else "off")
 
 
 async def test_sound_switch_has_unique_id(

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,7 @@ wheels = [
 
 [[package]]
 name = "ha-ttlock-ble"
-version = "3.8.0"
+version = "3.9.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -1155,7 +1155,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.354" },
     { name = "serialx", specifier = "==1.8.2" },
-    { name = "ttlock-ble", specifier = "==0.3.0" },
+    { name = "ttlock-ble", specifier = "==0.3.2" },
 ]
 lint = [
     { name = "mypy", specifier = "==2.3.1" },
@@ -2734,7 +2734,7 @@ wheels = [
 
 [[package]]
 name = "ttlock-ble"
-version = "0.3.0"
+version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
@@ -2742,9 +2742,9 @@ dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/c3/dc8175a9cf6161a9096f64d610abb5a7ed48927456f407555c6a7479d6c8/ttlock_ble-0.3.0.tar.gz", hash = "sha256:ccc86e683c3feea30fa05fe2980800731eca4ed233c7c4e6434af629c913e88a", size = 55656, upload-time = "2026-08-30T02:03:25.138Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/2e/74cfbd072a59f34540c9a3390f1653d66da92f64c2cafc6abd9b72f50f99/ttlock_ble-0.3.2.tar.gz", hash = "sha256:47e1c07d51623d04ad0f47acbc3b9e88093891cd67beaaed42c939504110b99e", size = 74933, upload-time = "2026-09-06T22:53:42.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/8f/abb2a6ec2d45e03fc1007c14d195acda5cfe908c38444312153b42324c98/ttlock_ble-0.3.0-py3-none-any.whl", hash = "sha256:09f547eea90a96c1b20a8ee662126678884a633b240ef62ce4658f3e85702d89", size = 69986, upload-time = "2026-08-30T02:03:24.138Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fd/03eb016664d58bff54edb946cff635c075b7c94bada0060486f255b84345/ttlock_ble-0.3.2-py3-none-any.whl", hash = "sha256:e4aa07b8830fb2147037bdf7bb12439ae52501553372db8e5b14f9a9e0ac8035", size = 94803, upload-time = "2026-09-06T22:53:41.332Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps the `ttlock-ble` SDK to 0.3.2 (manifest and dev pin together) and classifies the operation-log record types it added, so the event entity keeps every record type accounted for.
- The sound switch stops reporting an assumed state. The coordinator reads the beep setting back from the lock on a session opened for something else (the poll after a command, or an advertised operation-log read that landed), never by connecting for it, and at most once an hour per lock. A write the lock accepted is adopted straight away and confirmed by the next read. The entity reports `unknown` until a session has carried a read.
- The admin check that gates the switch now lives in one place and is applied before the read as well, so a key without the admin passcode is never asked.

## Verification

- `ruff format --check`, `ruff check`, `mypy` and `pytest` pass (401 tests, 100% coverage).
- Confirmed against a physical lock: the first session after startup carried the read and the switch moved from `unknown` to the value the lock reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
